### PR TITLE
Exclude non-local service and national numbers from geocoding in Finland

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -51,6 +51,7 @@ Fredrik Roubert
 Alec McTurk
 Alexandru Manea
 András Eisenberger
+Anssi Hannula
 Boshi Lian -- Maintains Chinese geocoding data
 Bradford Smith
 Cecilia Roes

--- a/resources/geocoding/en/358.txt
+++ b/resources/geocoding/en/358.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # Generated from:
+# http://www.viestintavirasto.fi/attachments/maaraykset/Regulation_32.pdf [2015-04-15]
 # http://en.wikipedia.org/wiki/+358 [437010438]
-# Expanded 3585 prefix to exclude mobile.
+# Some prefixes expanded to exclude mobile/nationwide numbers.
 
 35813|North Karelia
 35814|Central Finland
@@ -23,8 +24,22 @@
 35817|Kuopio
 35818|Åland Islands
 35819|Nylandia
-3582|Turku/Pori
-3583|Tavastia
+35821|Turku/Pori
+35822|Turku/Pori
+35823|Turku/Pori
+35824|Turku/Pori
+35825|Turku/Pori
+35826|Turku/Pori
+35827|Turku/Pori
+35828|Turku/Pori
+35831|Tavastia
+35832|Tavastia
+35833|Tavastia
+35834|Tavastia
+35835|Tavastia
+35836|Tavastia
+35837|Tavastia
+35838|Tavastia
 35851|Kymi
 35852|Kymi
 35853|Kymi
@@ -33,6 +48,27 @@
 35856|Kymi
 35857|Kymi
 35858|Kymi
-3586|Vaasa
-3588|Oulu
-3589|Helsinki
+35861|Vaasa
+35862|Vaasa
+35863|Vaasa
+35864|Vaasa
+35865|Vaasa
+35866|Vaasa
+35867|Vaasa
+35868|Vaasa
+35881|Oulu
+35882|Oulu
+35883|Oulu
+35884|Oulu
+35885|Oulu
+35886|Oulu
+35887|Oulu
+35888|Oulu
+35891|Helsinki
+35892|Helsinki
+35893|Helsinki
+35894|Helsinki
+35895|Helsinki
+35896|Helsinki
+35897|Helsinki
+35898|Helsinki

--- a/resources/geocoding/fi/358.txt
+++ b/resources/geocoding/fi/358.txt
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # Generated from:
-# http://www.ficora.fi/attachments/suomial/5ssVLe7t3/Kansallinen_numerointisuunnitelma_1_10_2010.pdf [2010-10-01]
+# http://www.viestintavirasto.fi/attachments/maaraykset/Regulation_32.pdf [2015-04-15]
 # http://en.wikipedia.org/wiki/+358 [437010438]
-# Expanded 3585 prefix to exclude mobile.
+# Some prefixes expanded to exclude mobile/nationwide numbers.
 
 35813|Pohjois-Karjala
 35814|Keski-Suomi
@@ -24,8 +24,22 @@
 35817|Kuopio
 35818|Ahvenanmaa
 35819|Uusimaa
-3582|Turku/Pori
-3583|Häme
+35821|Turku/Pori
+35822|Turku/Pori
+35823|Turku/Pori
+35824|Turku/Pori
+35825|Turku/Pori
+35826|Turku/Pori
+35827|Turku/Pori
+35828|Turku/Pori
+35831|Häme
+35832|Häme
+35833|Häme
+35834|Häme
+35835|Häme
+35836|Häme
+35837|Häme
+35838|Häme
 35851|Kymi
 35852|Kymi
 35853|Kymi
@@ -34,6 +48,27 @@
 35856|Kymi
 35857|Kymi
 35858|Kymi
-3586|Vaasa
-3588|Oulu
-3589|Helsinki
+35861|Vaasa
+35862|Vaasa
+35863|Vaasa
+35864|Vaasa
+35865|Vaasa
+35866|Vaasa
+35867|Vaasa
+35868|Vaasa
+35881|Oulu
+35882|Oulu
+35883|Oulu
+35884|Oulu
+35885|Oulu
+35886|Oulu
+35887|Oulu
+35888|Oulu
+35891|Helsinki
+35892|Helsinki
+35893|Helsinki
+35894|Helsinki
+35895|Helsinki
+35896|Helsinki
+35897|Helsinki
+35898|Helsinki

--- a/resources/geocoding/se/358.txt
+++ b/resources/geocoding/se/358.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # Generated from:
+# http://www.viestintavirasto.fi/attachments/maaraykset/Regulation_32.pdf [2015-04-15]
 # http://en.wikipedia.org/wiki/+358 [437010438]
-# Expanded 3585 prefix to exclude mobile.
+# Some prefixes expanded to exclude mobile/nationwide numbers.
 
 35813|Norra Karelen
 35814|Mellersta Finland
@@ -23,8 +24,22 @@
 35817|Kuopio
 35818|Åland
 35819|Nyland
-3582|Åbo/Björneborg
-3583|Tavastland
+35821|Åbo/Björneborg
+35822|Åbo/Björneborg
+35823|Åbo/Björneborg
+35824|Åbo/Björneborg
+35825|Åbo/Björneborg
+35826|Åbo/Björneborg
+35827|Åbo/Björneborg
+35828|Åbo/Björneborg
+35831|Tavastland
+35832|Tavastland
+35833|Tavastland
+35834|Tavastland
+35835|Tavastland
+35836|Tavastland
+35837|Tavastland
+35838|Tavastland
 35851|Kymmene
 35852|Kymmene
 35853|Kymmene
@@ -33,6 +48,27 @@
 35856|Kymmene
 35857|Kymmene
 35858|Kymmene
-3586|Vasa
-3588|Uleåborg
-3589|Helsingfors
+35861|Vasa
+35862|Vasa
+35863|Vasa
+35864|Vasa
+35865|Vasa
+35866|Vasa
+35867|Vasa
+35868|Vasa
+35881|Uleåborg
+35882|Uleåborg
+35883|Uleåborg
+35884|Uleåborg
+35885|Uleåborg
+35886|Uleåborg
+35887|Uleåborg
+35888|Uleåborg
+35891|Helsingfors
+35892|Helsingfors
+35893|Helsingfors
+35894|Helsingfors
+35895|Helsingfors
+35896|Helsingfors
+35897|Helsingfors
+35898|Helsingfors


### PR DESCRIPTION
This is a copy of https://codereview.appspot.com/174570043/ . Since there was no activity there and libphonenumber has now moved to github, here is a PR instead.

Per http://www.viestintavirasto.fi/attachments/maaraykset/Maarays_32.pdf
(official numbering plan), in Finland (+358):

- 020*: National service and subscriber numbers
- 029*: National subscriber numbers
- 030*: National service and subscriber numbers
- 039*: National subscriber numbers
- 060*: National service numbers
- 0800*: National toll-free service numbers

The local subscriber numbers starting with 02,03,06,08 have 1..8 as
their third number.

However, libphonenumber assigns 02*, 03*, 06* and 08* to specific
locations in their entirety, causing e.g. some national service numbers
to be incorrectly geocoded.

Instead of using catch-all geocoding for 02,03,06,08, add the actually
local subscriber telephone number allocations 0X[1-8] separately.