### PR TITLE
Clean compile with CMAKE_BUILD_TYPE=RELEASE

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.cc
+++ b/cpp/src/phonenumbers/asyoutypeformatter.cc
@@ -114,6 +114,7 @@ void MatchAllGroups(const string& pattern,
   bool status =
       cache->GetRegExp(new_pattern).Consume(consume_input.get(), group);
   DCHECK(status);
+  IGNORE_UNUSED(status);
 }
 
 PhoneMetadata CreateEmptyMetadata() {
@@ -507,6 +508,7 @@ void AsYouTypeFormatter::AttemptToFormatAccruedDigits(
       bool status = regexp_cache_.GetRegExp(pattern).GlobalReplace(
           &formatted_number, number_format.format());
       DCHECK(status);
+      IGNORE_UNUSED(status);
 
       AppendNationalNumber(formatted_number, formatted_result);
       return;

--- a/cpp/src/phonenumbers/base/logging.h
+++ b/cpp/src/phonenumbers/base/logging.h
@@ -38,4 +38,8 @@ template <typename T> T* CHECK_NOTNULL(T* ptr) {
   return ptr;
 }
 
+#if !defined(IGNORE_UNUSED)
+#define IGNORE_UNUSED(X) (void)(X)
+#endif 
+
 #endif  // I18N_PHONENUMBERS_BASE_LOGGING_H_

--- a/cpp/test/phonenumbers/geocoding/geocoding_test_program.cc
+++ b/cpp/test/phonenumbers/geocoding/geocoding_test_program.cc
@@ -33,6 +33,7 @@ int main() {
   const PhoneNumberUtil::ErrorType status = phone_util.Parse(
       "16502530000", "US", &number);
   CHECK_EQ(status, PhoneNumberUtil::NO_PARSING_ERROR);
+  IGNORE_UNUSED(status);
 
   const std::string description =
       PhoneNumberOfflineGeocoder().GetDescriptionForNumber(


### PR DESCRIPTION
Fix unused-variable warnings when building with CMAKE_BUILD_TYPE=RELEASE