### PR TITLE
New mobile ranges in IN, PK, MY, MA, NG, TZ

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -6536,7 +6536,7 @@
             0[0-8]|
             [12-7]\d|
             8[01]|
-            9[2457-9]
+            9\d
           )\d{6}
         </nationalNumberPattern>
         <exampleNumber>650123456</exampleNumber>
@@ -10605,7 +10605,7 @@
               0(?:
                 2[2-9]|
                 [3-8]\d|
-                9[0-4]
+                9[0-8]
               )|
               2(?:
                 0[04-9]|
@@ -14841,7 +14841,7 @@
             0[0-8]|
             [12-7]\d|
             8[01]|
-            9[2457-9]
+            9\d
           )\d{6}
         </nationalNumberPattern>
         <exampleNumber>650123456</exampleNumber>
@@ -16615,7 +16615,7 @@
              listing them as mobile. -->
         <nationalNumberPattern>
           1(?:
-            1[1-3]\d{2}|
+            1[1-35]\d{2}|
             [02-4679][2-9]\d|
             59\d{2}|
             8(?:
@@ -17174,7 +17174,7 @@
               0[2-9]|
               1\d
             )\d|
-            90[239]\d
+            90[2359]\d
           )\d{6}
         </nationalNumberPattern>
         <possibleNumberPattern>\d{8,10}</possibleNumberPattern>
@@ -18538,7 +18538,7 @@
         <nationalNumberPattern>
           3(?:
             0\d|
-            [12][0-5]|
+            [12][0-6]|
             3[1-7]|
             4[0-7]|
             55|
@@ -22179,7 +22179,7 @@
       <mobile>
         <nationalNumberPattern>
           (?:
-            6[158]|
+            6[1578]|
             7[1-9]
           )\d{7}
         </nationalNumberPattern>


### PR DESCRIPTION
India
Example numbers
9170970752xx
9170951129xx
9170963229xx
9170983005xx

Pakistan
Zong introduced 316 prefix
Example numbers:
9231666724xx
9231640942xx

Malaysia
Altel, a Celcom MVNO, is now using 115 prefix
Examples:
6011520000xx

Morocco
inwi started using 690/691/696 prefixes
Example numbers:
2126909699xx
2126909573xx

Nigeria
Globalcom is using 905 prefix
Examples:
23490510474xx
23490506139xx

Tanzania
Tigo started using 67 prefix