### PR TITLE
Add node port (npm package) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ Several people are porting the phone number library to other languages. Here are
   * Python: https://github.com/daviddrysdale/python-phonenumbers
   * Ruby: https://github.com/sstephenson/global_phone
   * PHP: https://github.com/giggsey/libphonenumber-for-php
+  * JavaScript (node): https://github.com/seegno/google-libphonenumber


### PR DESCRIPTION
I've added the node port which is basically an npm package wrapper for the javascript version of this library. It is very convenient for node.js developers to be able to just require this.