### PR TITLE
Metadata update 20150215

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -4171,7 +4171,7 @@
           <nationalNumberPattern>
           (?:
             0[1-9]|
-            4[0-24-9]|
+            4\d|
             5[4-9]|
             6[015-79]|
             7[57]
@@ -4410,7 +4410,7 @@
       <mobile>
         <!-- Temporarily allow both old [579]\d{7} and new 6[5-79]\d{7} format. -->
         <nationalNumberPattern>
-          6[5-79]\d{7}|
+          6[5-9]\d{7}|
           [579]\d{7}
         </nationalNumberPattern>
         <exampleNumber>671234567</exampleNumber>
@@ -8259,7 +8259,7 @@
             2[034678]\d|
             5(?:
               [047]\d|
-              54|
+              5[3-6]|
               6[01]
             )
           )\d{6}
@@ -12979,7 +12979,7 @@
             6[016-9]|
             7(?:
               [07-9]|
-              6\d
+              [16]\d
             )|
             8(?:
               [013-79]|
@@ -16581,7 +16581,7 @@
              listing them as mobile. 115 was added based on numbers found online. -->
         <nationalNumberPattern>
           1(?:
-            1[1-35]\d{2}|
+            1[1-5]\d{2}|
             [02-4679][2-9]\d|
             59\d{2}|
             8(?:


### PR DESCRIPTION
Côte d'Ivoire
Added prefix 43 used by Moov

Example numbers:
225430433xx
225430468xx
225430587xx

Cameroon
Prefix 68 used by MTN

Example numbers:
23768049898x
23768051012x
23768051097x

Ghana
Added prefixex 53,55,56 used by MTN

Example numbers:
23355349471x
23355546419x
23355568525x

Cambodia
Metfone started using 71 prefix

Examples:
85571498371x

Malaysia
Celcom started using 114 prefix for mobile numbers.

Example numbers:
60114038743x
60114038805x
60114038908x
60114039224x
60114039401x