### PR TITLE
Fix bug in AsYouTypeFormatter where we hit a IndexOutOfBoundsException

### DIFF
--- a/cpp/src/phonenumbers/asyoutypeformatter.cc
+++ b/cpp/src/phonenumbers/asyoutypeformatter.cc
@@ -466,6 +466,9 @@ void AsYouTypeFormatter::AttemptToChoosePatternWithPrefixExtracted(
   able_to_format_ = true;
   is_expecting_country_code_ = false;
   possible_formats_.clear();
+  last_match_position_ = 0;
+  formatting_template_.remove();
+  current_formatting_pattern_.clear();
   AttemptToChooseFormattingPattern(formatted_number);
 }
 

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/AsYouTypeFormatter.java
@@ -390,6 +390,9 @@ public class AsYouTypeFormatter {
     ableToFormat = true;
     isExpectingCountryCallingCode = false;
     possibleFormats.clear();
+    lastMatchPosition = 0;
+    formattingTemplate.setLength(0);
+    currentFormattingPattern = "";
     return attemptToChooseFormattingPattern();
   }
 
@@ -637,6 +640,8 @@ public class AsYouTypeFormatter {
   }
 
   private String inputDigitHelper(char nextChar) {
+    // Note that formattingTemplate is not guaranteed to have a value, it could be empty, e.g.
+    // when the next digit is entered after extracting an IDD or NDD.
     Matcher digitMatcher = DIGIT_PATTERN.matcher(formattingTemplate);
     if (digitMatcher.find(lastMatchPosition)) {
       String tempTemplate = digitMatcher.replaceFirst(Character.toString(nextChar));

--- a/javascript/i18n/phonenumbers/asyoutypeformatter.js
+++ b/javascript/i18n/phonenumbers/asyoutypeformatter.js
@@ -667,6 +667,9 @@ i18n.phonenumbers.AsYouTypeFormatter.prototype.
   this.ableToFormat_ = true;
   this.isExpectingCountryCallingCode_ = false;
   this.possibleFormats_ = [];
+  this.lastMatchPosition_ = 0;
+  this.formattingTemplate_.clear();
+  this.currentFormattingPattern_ = '';
   return this.attemptToChooseFormattingPattern_();
 };
 


### PR DESCRIPTION
in its Java implementation when extracting the Chinese national prefix 17951 and didn't reset the format template / lastMatchPosition.

Includes corresponding changes for C++ and JavaScript as well to keep the implementations in sync. (C++ and JS didn't exhibit buggy behavior because the corresponding substring methods don't throw errors for invalid start positions.)

Bugfix for https://github.com/googlei18n/libphonenumber/issues/592