### PR TITLE
Update debian/watch URL to point to new GitHub project.

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=3
-https://github.com/libphonenumber/libphonenumber/tags \
+https://github.com/googlei18n/libphonenumber/tags \
   .*/archive/libphonenumber-(\d[\d\.]+)\.tar\.gz


### PR DESCRIPTION
The old libphonenumber/libphonenumber has been abandoned in favour of
the new googlei18n/libphonenumber project.