### PR TITLE
revert timezones map_data copyright year

### DIFF
--- a/resources/timezones/map_data.txt
+++ b/resources/timezones/map_data.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 The Libphonenumber Authors
+# Copyright (C) 2012 The Libphonenumber Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This was accidentally updated by script, and should have been left as the original year.