### PR TITLE
Test scripts pass in release builds too

### DIFF
--- a/cpp/test/phonenumbers/shortnumberinfo_test.cc
+++ b/cpp/test/phonenumbers/shortnumberinfo_test.cc
@@ -36,8 +36,10 @@ class ShortNumberInfoTest : public testing::Test {
   PhoneNumber ParseNumberForTesting(const string& number,
                                     const string& region_code) {
     PhoneNumber phone_number;
-    CHECK_EQ(phone_util_.Parse(number, region_code, &phone_number),
-             PhoneNumberUtil::NO_PARSING_ERROR);
+    PhoneNumberUtil::ErrorType error_type = phone_util_.Parse(
+                                           number, region_code, &phone_number);
+    CHECK_EQ(error_type, PhoneNumberUtil::NO_PARSING_ERROR);
+    IGNORE_UNUSED(error_type);
     return phone_number;
   }
 


### PR DESCRIPTION
Test scripts were failing if compiled as release builds, that is via `cmake -DCMAKE_BUILD_TYPE=RELEASE`.

That's because necessary parsing was happening inside an assertion that gets compiled out.  This fixes that.