### PR TITLE
Small metadata update for AS, IN & NE

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -1218,7 +1218,10 @@
         <!-- Added 25[246], operated from Blue Sky. Added 731, 770, operated by ASTCA. -->
         <nationalNumberPattern>
           684(?:
-            25[2468]|
+            2(?:
+              5[2468]|
+              72
+            )|
             7(?:
               3[13]|
               70
@@ -10704,6 +10707,7 @@
               )|
               2(?:
                 0[04-9]|
+                10|
                 5[09]|
                 7[5-8]|
                 9[389]
@@ -17016,7 +17020,7 @@
              89 and 97 prefixes, and Orange use 92. MOOV started using 95 in Jan 2014. -->
         <nationalNumberPattern>
           (?:
-            89|
+            8[89]|
             9\d
           )\d{6}
         </nationalNumberPattern>


### PR DESCRIPTION
American Samoa - Blue sky is now using 1-684-272 -
http://localcallingguide.com/lca_prefix.php?npa=684
examples:
168427216xx
168427252xx

India - 7210 is being used by Aircel
examples:
9172104311xx
9172104313xx
9172104348xx

Niger - Airtel introduced 88 prefix
examples:
227881204xx
227881263xx
227881333xx
227881340xx