### PR TITLE
9012345678 is a better mobile example for Japan

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -12760,7 +12760,7 @@
       <mobile>
         <nationalNumberPattern>[7-9]0[1-9]\d{7}</nationalNumberPattern>
         <possibleNumberPattern>\d{10}</possibleNumberPattern>
-        <exampleNumber>8012345678</exampleNumber>
+        <exampleNumber>9012345678</exampleNumber>
       </mobile>
       <pager>
         <nationalNumberPattern>20\d{8}</nationalNumberPattern>

--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -12760,7 +12760,7 @@
       <mobile>
         <nationalNumberPattern>[7-9]0[1-9]\d{7}</nationalNumberPattern>
         <possibleNumberPattern>\d{10}</possibleNumberPattern>
-        <exampleNumber>7012345678</exampleNumber>
+        <exampleNumber>8012345678</exampleNumber>
       </mobile>
       <pager>
         <nationalNumberPattern>20\d{8}</nationalNumberPattern>


### PR DESCRIPTION
The current JP mobile example number 7012345678, while technically valid, looks strange to most Japanese people. 070- mobile numbers are reserved for PHS (Personal Handy-phone System) which is a legacy technology that is not commonly used. 090- are more common.