### PR TITLE
Remove return from finally block.

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -664,10 +664,9 @@ public class PhoneNumberUtil {
         source.close();
       } catch (IOException e) {
         logger.log(Level.WARNING, "error closing input stream (ignored)", e);
-      } finally {
-        return metadataCollection;
       }
     }
+    return metadataCollection;
   }
 
   /**


### PR DESCRIPTION
Returning in finally blocks can be dangerous: 
https://weblogs.java.net/blog/2007/06/27/dont-return-finally-clause
