### PR TITLE
Orange Cameroon - new number range

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -4491,7 +4491,7 @@
       <mobile>
         <!-- Temporarily allow both old [579]\d{7} and new 6[5-79]\d{7} format. -->
         <nationalNumberPattern>
-          6[5-79]\d{7}|
+          6[5-9]\d{7}|
           [579]\d{7}
         </nationalNumberPattern>
         <exampleNumber>671234567</exampleNumber>


### PR DESCRIPTION
Orange Cameroon is using mobile number prefix +237-68