### PR TITLE
Celcom/Altel MY new number range

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -16658,7 +16658,7 @@
              listing them as mobile. 115 was added based on numbers found online. -->
         <nationalNumberPattern>
           1(?:
-            1[1-35]\d{2}|
+            1[1-5]\d{2}|
             [02-4679][2-9]\d|
             59\d{2}|
             8(?:


### PR DESCRIPTION
Celcom MY introduced a new number series +60114 that is used by their
MVNO Altel.