### PR TITLE
Fix NullPointerException when ShortNumberInfo.isPossibleShortNumber is used with a region not in ShortNumberMetadata

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java
@@ -156,6 +156,9 @@ public class ShortNumberInfo {
     String shortNumber = getNationalSignificantNumber(number);
     for (String region : regionCodes) {
       PhoneMetadata phoneMetadata = MetadataManager.getShortNumberMetadataForRegion(region);
+      if (phoneMetadata == null) {
+        continue;
+      }
       if (matcherApi.matchesPossibleNumber(shortNumber, phoneMetadata.getGeneralDesc())) {
         return true;
       }


### PR DESCRIPTION
Example code:

```java
import com.google.i18n.phonenumbers.*;
import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;

public class Test {

	/**
	 * @param args
	 */
	public static void main(String[] args) {
        PhoneNumber phoneNumber = null;
        PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
        phoneNumber = phoneNumberUtil.getExampleNumber("NE");

        ShortNumberInfo shortNumberInfo = ShortNumberInfo.getInstance();

        shortNumberInfo.isPossibleShortNumber(phoneNumber);

	}

}
```

`NE` is a valid region, and exists in PhoneNumberMetadata. This means that the check in [`getRegionCodesForCountryCode`](https://github.com/googlei18n/libphonenumber/blob/master/java/libphonenumber/src/com/google/i18n/phonenumbers/ShortNumberInfo.java#L97) returns the correct region code.

It then loops through, loading the metadata for each region, but doesn't actually check whether the metadata exists.


Credit to @RuslanGetmansky via https://github.com/giggsey/libphonenumber-for-php/issues/68


I haven't updated any unit tests for this, but I can do if needed (my Java is not very good)