### PR TITLE
Changes the format of Brazilian nine digits mobile numbers...

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -3163,14 +3163,14 @@
           <format>$1-$2</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
-        <numberFormat nationalPrefixFormattingRule="$FG" pattern="(\d{5})(\d{4})">
+        <numberFormat nationalPrefixFormattingRule="$FG" pattern="(\d{3})(\d{3})(\d{3})">
           <leadingDigits>
             9(?:
               [1-9]|
               0[1-9]
             )
           </leadingDigits>
-          <format>$1-$2</format>
+          <format>$1-$2-$3</format>
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <!-- Format short numbers as a block. -->
@@ -3180,7 +3180,7 @@
           <intlFormat>NA</intlFormat>
         </numberFormat>
         <numberFormat nationalPrefixFormattingRule="($FG)"
-            pattern="(\d{2})(\d{5})(\d{4})"
+            pattern="(\d{2})(\d{3})(\d{3})(\d{3})"
             carrierCodeFormattingRule="$NP $CC ($FG)">
           <leadingDigits>
             (?:
@@ -3188,7 +3188,7 @@
               2[12478]
             )9
           </leadingDigits>
-          <format>$1 $2-$3</format>
+          <format>$1 $2-$3-$4</format>
         </numberFormat>
         <numberFormat nationalPrefixFormattingRule="($FG)"
             pattern="(\d{2})(\d{4})(\d{4})"


### PR DESCRIPTION
… to the more readable 999-999-999 instead of 99999-9999

Since July 2012 Brazilian mobile numbers have been changing from the old format:
AA99999999 : 2 digits for the area code, 8 digits for the actual number
to
AA**9**99999999: 2 digits for the area code, a fixed (for now) digit **9**, and the old 8 digits for the number

The national format in this library stated the those 9 digits numbers should be formated as:
(AA) **9**9999-9999

That format makes most numbers quite unreadable, since Brazilian mobile numbers, in most States, already started with a 9, making several numers like:
(11) 99995-3214 (invented number)

The proposal changes the format to the much more readable:
(11) 999-953-214
![libphonenumber-brazilian-mobile-numbers](https://cloud.githubusercontent.com/assets/185558/8877665/de4fa300-31fc-11e5-96ef-b7692042fd2a.png)