### PR TITLE
Kenya mobiles are always 9 digit national numbers

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -12962,7 +12962,7 @@
           <leadingDigits>[24-6]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
-        <numberFormat pattern="(\d{3})(\d{6,7})">
+        <numberFormat pattern="(\d{3})(\d{6})">
           <leadingDigits>7</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>


### PR DESCRIPTION
Kenya mobile phone numbers are always exactly 9 digits after the country code. (Wikipedia used to think that they could be 10 digits, but that is wrong; I fixed that also.)

https://en.wikipedia.org/wiki/Telephone_numbers_in_Kenya#Mobile_phone_numbers

At this time the Communication Authority of Kenya's website (http://www.ca.go.ke/) is offline but I contacted Safaricom (a major mobile operator in Kenya) and they confirmed this on their support line. I also confirmed it with two friends who live & work in Kenya.

(Apologies if this is the wrong way to submit patches; I wasn't able to figure out the Rietveld code review tool.)