### PR TITLE
Fix phone number match.

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -2741,6 +2741,10 @@ PhoneNumberUtil::MatchType PhoneNumberUtil::IsNumberMatchWithOneString(
       PhoneNumber second_number_with_first_number_region;
       Parse(second_number, first_number_region,
             &second_number_with_first_number_region);
+
+      if (!IsPossibleNumber(second_number_with_first_number_region)) {
+          return NO_MATCH;
+      }
       MatchType match = IsNumberMatch(first_number,
                                       second_number_with_first_number_region);
       if (match == EXACT_MATCH) {

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -2809,6 +2809,9 @@ TEST_F(PhoneNumberUtilTest, IsNumberMatchNonMatches) {
   EXPECT_EQ(PhoneNumberUtil::NO_MATCH,
             phone_util_.IsNumberMatchWithTwoStrings("+64 3 331-6005 ext.1235",
                                                     "3 331 6005#1234"));
+  EXPECT_EQ(PhoneNumberUtil::NO_MATCH,
+            phone_util_.IsNumberMatchWithTwoStrings("+28909", "+13611361530"));
+
   // Invalid numbers that can't be parsed.
   EXPECT_EQ(PhoneNumberUtil::INVALID_NUMBER,
             phone_util_.IsNumberMatchWithTwoStrings("4", "3 331 6043"));


### PR DESCRIPTION
Trying to match: "+28909" with "+13611361530" should return  "NO_MATCH";
