### PR TITLE
replaced Novafone prefix 5 to 555 by Liberia

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -14489,7 +14489,8 @@
         <nationalNumberPattern>
           2\d{7}|
           [37-9]\d{8}|
-          [45]\d{6}
+          4\d{6}|
+          5\d{8}
         </nationalNumberPattern>
         <possibleNumberPattern>\d{7,9}</possibleNumberPattern>
       </generalDesc>
@@ -14506,7 +14507,7 @@
           (?:
             330\d|
             4[67]|
-            5\d|
+            555\d|
             77\d{2}|
             88\d{2}|
             994\d


### PR DESCRIPTION
> NOVAFONE, in accordance with the directives of the Liberia Telecommunications Authority(LTA) launched on Sept 19th the new ten digits numbering plan.

> According to a communication from the company the previous "05" will be replaced by "0555". Novafone said it is very important to note that subscribers need to add "55" to the existing code of "05", followed by the NOVAFONE number.

The sources are:
http://allafrica.com/stories/201309232245.html
http://allafrica.com/stories/201309232166.html

This update has been reflected already on the ITU document about numbering plan of Liberia: http://www.itu.int/oth/T0202000079/en