### PR TITLE
Include protobuf dependencies in libphonenumber.jar

### DIFF
--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -30,18 +30,25 @@
     </testResources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>**/SingleFileMetadataSourceImpl.class</exclude>
-            <exclude>**/SingleFileMetadataSourceImpl.java</exclude>
-            <exclude>**/SingleFileMetadataSourceImplTest.class</exclude>
-            <exclude>**/SingleFileMetadataSourceImplTest.java</exclude>
-            <exclude>**/SingleFilePhoneNumberMetadataProto</exclude>
-            <exclude>**/SingleFilePhoneNumberMetadataProtoForTesting</exclude>
+            <exclude>com/google/i18n/phonenumbers/SingleFileMetadataSourceImpl.class</exclude>
+            <exclude>com/google/i18n/phonenumbers/data/SingleFilePhoneNumberMetadataProto</exclude>
           </excludes>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Before this change, running ```mvn package``` form java/libphonenumber adds the following JARs in java/libphonenumber/target
```
libphonenumber-7.2.1-SNAPSHOT.jar
libphonenumber-7.2.1-SNAPSHOT-javadoc.jar
libphonenumber-7.2.1-SNAPSHOT-sources.jar
```

After this change it adds
```
libphonenumber-7.2.1-SNAPSHOT.jar
libphonenumber-7.2.1-SNAPSHOT-javadoc.jar
libphonenumber-7.2.1-SNAPSHOT-sources.jar
original-libphonenumber-7.2.1-SNAPSHOT.jar
``` 
where libphonenumber-7.2.1-SNAPSHOT.jar contains protobuf dependencies.

Diffs: ~keghani/GitHub_diffs/bbba20d
* libphonenumber-7.2.1-SNAPSHOT.jar CHANGED (78.6%):
    + Added 298 com/google/protobuf/ Java classes
    + Added META-INF/maven/com.google.protobuf/protobuf-java/pom.xml
    + Added META-INF/maven/com.google.protobuf/protobuf-java/pom.properties
    + Added 5 protobuf-related directories
    + Changed META-INF/maven/com.googlecode.libphonenumber/libphonenumber/pom.xml
    + Changed META-INF/maven/com.googlecode.libphonenumber/libphonenumber/pom.properties
* libphonenumber-7.2.1-SNAPSHOT-javadoc.jar CHANGED (8.1%): 81 HTML pages changed
* libphonenumber-7.2.1-SNAPSHOT-sources.jar UNCHANGED
* original-libphonenumber-7.2.1-SNAPSHOT.jar is the old libphonenumber-7.2.1-SNAPSHOT.jar plus 2 libphonenumber/pom changes