### PR TITLE
Fix IllegalStateException in MultiFileMetadataSourceImpl

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,7 +87,14 @@ final class MultiFileMetadataSourceImpl implements MetadataSource {
   public PhoneMetadata getMetadataForNonGeographicalRegion(int countryCallingCode) {
     synchronized (countryCodeToNonGeographicalMetadataMap) {
       if (!countryCodeToNonGeographicalMetadataMap.containsKey(countryCallingCode)) {
-        loadMetadataFromFile(PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY, countryCallingCode);
+        List<String> regionCodes =
+            CountryCodeToRegionCodeMap.getCountryCodeToRegionCodeMap().get(countryCallingCode);
+        // We can assume that if the country calling code maps to the non-geo entity region code
+        // then that's the only region code it maps to.
+        if (regionCodes.size() == 1 &&
+            PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY.equals(regionCodes.get(0))) {
+          loadMetadataFromFile(PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY, countryCallingCode);
+        }
       }
     }
     return countryCodeToNonGeographicalMetadataMap.get(countryCallingCode);

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -552,7 +552,7 @@ public class PhoneNumberUtil {
   // load factor of roughly 0.75.
   private final Set<String> supportedRegions = new HashSet<String>(320);
 
-  // The set of county calling codes that map to the non-geo entity region ("001"). This set
+  // The set of country calling codes that map to the non-geo entity region ("001"). This set
   // currently contains < 12 elements so the default capacity of 16 (load factor=0.75) is fine.
   private final Set<Integer> countryCodesForNonGeographicalRegion = new HashSet<Integer>();
 
@@ -566,7 +566,7 @@ public class PhoneNumberUtil {
     this.countryCallingCodeToRegionCodeMap = countryCallingCodeToRegionCodeMap;
     for (Map.Entry<Integer, List<String>> entry : countryCallingCodeToRegionCodeMap.entrySet()) {
       List<String> regionCodes = entry.getValue();
-      // We can assume that if the county calling code maps to the non-geo entity region code then
+      // We can assume that if the country calling code maps to the non-geo entity region code then
       // that's the only region code it maps to.
       if (regionCodes.size() == 1 && REGION_CODE_FOR_NON_GEO_ENTITY.equals(regionCodes.get(0))) {
         // This is the subset of all country codes that map to the non-geo entity region code.

--- a/java/release_notes.txt
+++ b/java/release_notes.txt
@@ -1,6 +1,8 @@
 Pending changes
 Code changes:
- - Fix two places in demo where NPEs can occur on bad input
+ - Fix two places in demo where NPEs can occur on bad input.
+ - Fix an IllegalStateException when getMetadataForNonGeographicalRegion is
+   called with a country calling code which isn't a non-geographic entity.
 
 Jan 28, 2016: libphonenumber-7.2.4
 Metadata changes:


### PR DESCRIPTION
The exception occurs when getMetadataForNonGeographicalRegion is called with a country calling code which doesn't correspond to a non-geographic entity.

Also fix a typo in PhoneNumberUtil.