### PR TITLE
Require CMake packages to be version 3.1 or higher.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: optional
 Maintainer: Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>
 Uploaders: Daniel Pocock <daniel@pocock.pro>, Fredrik Roubert <roubert@google.com>
 Build-Depends: cdbs,
-               cmake,
+               cmake (>= 3.1),
                debhelper (>= 9),
                default-jdk | java-sdk,
                libboost-dev (>= 1.40),


### PR DESCRIPTION
This has become necessary after commit 15084a9.