### PR TITLE
Mark method CountryCodeToRegionCodeMap#getCountryCodeToRegionCodeMap as public

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/CountryCodeToRegionCodeMap.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/CountryCodeToRegionCodeMap.java
@@ -26,11 +26,15 @@ import java.util.List;
 import java.util.Map;
 
 public class CountryCodeToRegionCodeMap {
-  // A mapping from a country code to the region codes which denote the
-  // country/region represented by that country code. In the case of multiple
-  // countries sharing a calling code, such as the NANPA countries, the one
-  // indicated with "isMainCountryForCode" in the metadata should be first.
-  static Map<Integer, List<String>> getCountryCodeToRegionCodeMap() {
+  /**
+   * A mapping from a country code to the region codes which denote the
+   * country/region represented by that country code. In the case of multiple
+   * countries sharing a calling code, such as the NANPA countries, the one
+   * indicated with "isMainCountryForCode" in the metadata should be first.
+   *
+   * @return mapping from a country code to the region codes
+   */
+  public static Map<Integer, List<String>> getCountryCodeToRegionCodeMap() {
     // The capacity is set to 285 as there are 214 different entries,
     // and this offers a load factor of roughly 0.75.
     Map<Integer, List<String>> countryCodeToRegionCodeMap =


### PR DESCRIPTION
In our project we used the following workaround to get access to the `CountryCodeToRegionCodeMap#getCountryCodeToRegionCodeMap` method:

```java
package com.google.i18n.phonenumbers;

import java.util.List;
import java.util.Map;
import java.util.Set;

public abstract class CountryCodeToRegionCodeMapWrapper {
    static final Map<Integer, List<String>> _CountryCodeToRegionCodeMap = CountryCodeToRegionCodeMap.getCountryCodeToRegionCodeMap();

    public static Map<Integer, List<String>> getCountryCodeToRegionCodeMap(){
        return _CountryCodeToRegionCodeMap;
    }
}
```

We put `CountryCodeToRegionCodeMapWrapper` class in the package `com.google.i18n.phonenumbers` to have access to this method. It will be very useful, to have direct access to this method without above hack.