### PR TITLE
Fixing issue with reg-exp when finding phone numbers in text

### DIFF
--- a/cpp/src/phonenumbers/phonenumbermatcher.cc
+++ b/cpp/src/phonenumbers/phonenumbermatcher.cc
@@ -339,7 +339,7 @@ class PhoneNumberMatcherRegExps : public Singleton<PhoneNumberMatcherRegExps> {
         // break two numbers without spaces, and we haven't seen many instances
         // of it used within a number.
         regexp_factory_->CreateRegExp(
-            "[\xE2\x80\x92-\x2D\xE2\x80\x95\xEF\xBC\x8D]" /* "‒-―－" */
+            "[\xE2\x80\x92-\xE2\x80\x95\xEF\xBC\x8D]" /* "‒-―－" */
             "\\p{Z}*(.+)"));
     inner_matches_->push_back(
         // Breaks on a full stop - e.g. "12345. 332-445-1234 is my number."


### PR DESCRIPTION
 The "-" range operator was duplicated as the end of the range as well, causing re2 to fail (and some test failures with newer versions of ICU apparently in some configurations)