### PR TITLE
Adding ifdef I18N_PHONENUMBERS_USE_ALTERNATE_FORMATS in phonenumbermatcher_test

### DIFF
--- a/cpp/test/phonenumbers/phonenumbermatcher_test.cc
+++ b/cpp/test/phonenumbers/phonenumbermatcher_test.cc
@@ -864,11 +864,15 @@ static const NumberTest kStrictGroupingCases[] = {
   // Should be found by strict grouping but not exact grouping, as the last two
   // groups are formatted together as a block.
   NumberTest("0800-2491234", RegionCode::DE()),
+  // If the user is using alternate formats, test that numbers formatted in
+  // that way are found.
+#ifdef I18N_PHONENUMBERS_USE_ALTERNATE_FORMATS
   // Doesn't match any formatting in the test file, but almost matches an
   // alternate format (the last two groups have been squashed together here).
   NumberTest("0900-1 123123", RegionCode::DE()),
   NumberTest("(0)900-1 123123", RegionCode::DE()),
   NumberTest("0 900-1 123123", RegionCode::DE()),
+#endif  // I18N_PHONENUMBERS_USE_ALTERNATE_FORMATS
   // NDC also found as part of the country calling code; this shouldn't ruin the
   // grouping expectations.
   NumberTest("+33 3 34 2312", RegionCode::FR()),
@@ -903,13 +907,17 @@ static const NumberTest kExactGroupingCases[] = {
   NumberTest("0494949 ext. 49", RegionCode::DE()),
   NumberTest("01 (33) 3461 2234", RegionCode::MX()),  // Optional NP present
   NumberTest("(33) 3461 2234", RegionCode::MX()),  // Optional NP omitted
-  // Breakdown assistance number with normal formatting.
+  // If the user is using alternate formats, test that numbers formatted in
+  // that way are found.
+#ifdef I18N_PHONENUMBERS_USE_ALTERNATE_FORMATS
+  // Breakdown assistance number using alternate formatting pattern.
   NumberTest("1800-10-10 22", RegionCode::AU()),
   // Doesn't match any formatting in the test file, but matches an alternate
   // format exactly.
   NumberTest("0900-1 123 123", RegionCode::DE()),
   NumberTest("(0)900-1 123 123", RegionCode::DE()),
   NumberTest("0 900-1 123 123", RegionCode::DE()),
+#endif  // I18N_PHONENUMBERS_USE_ALTERNATE_FORMATS
   NumberTest("+33 3 34 23 12", RegionCode::FR()),
 };
 


### PR DESCRIPTION
Fixed issue with failing tests for users who choose not to use alternate formats.

Added "ifdef" around the entries in phonenumbermatcher_test that require alternate formats to be included to be found. This means that if the user doesn't have this option set to true, the tests won't be run (they would otherwise fail).