### PR TITLE
Add cmake Mac flag to enable Linux builds at lower cmake versions.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Author: Philippe Liard
 
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 2.8)
 
 project (libphonenumber)
 set (libphonenumber_VERSION_MAJOR 7)
@@ -126,6 +126,7 @@ find_required_program (JAVA java
 if (APPLE)
   FIND_LIBRARY (COREFOUNDATION_LIB CoreFoundation)
   FIND_LIBRARY (FOUNDATION_LIB Foundation)
+  set (CMAKE_MACOSX_RPATH "OFF")
   set (CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS
     "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif ()

--- a/cpp/README
+++ b/cpp/README
@@ -56,7 +56,7 @@ Requirements:
     recent Debian-based GNU/Linux distributions).
 
     You can check which version is available:
-    $ apt-cache show libprotobuf-dev 
+    $ apt-cache show libprotobuf-dev
     Package: libprotobuf-dev
     Source: protobuf
     Version: 2.5.0-9ubuntu1   <-- This must be >= 2.4.0
@@ -138,6 +138,62 @@ Building and testing the library
   $ make
   $ ./libphonenumber_test
 
+
+Manually installing the library on Mac
+--------------------------------------
+
+You can easily install dependencies on Mac using a package manager. In these
+instructions we use Homebrew (http://brew.sh).
+
+Install Homebrew package manager and use it to install dependencies:
+  $ /usr/bin/ruby -e "$(curl -fsSL \
+    https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  $ brew install boost cmake icu4c pkg-config protobuf wget
+
+See https://github.com/Homebrew/homebrew/issues/14099 - homebrew does not have
+gtest. We don't need to install gtest, we only copy sources. For example:
+  $ mkdir ~/googletest_clone
+  $ cd ~/googletest_clone
+  $ git clone https://github.com/google/googletest.git
+
+Get the libphonenumber source. For example:
+  $ mkdir ~/libphonenumber_clone
+  $ cd ~/libphonenumber_clone
+  $ git clone https://github.com/googlei18n/libphonenumber.git
+
+Build and test the library:
+  $ cd libphonenumber/cpp
+  $ mkdir build
+  $ cd build
+  Replace XXX with the appropriate version number:
+  $ cmake \
+    -DGTEST_SOURCE_DIR=~/googletest_clone/googletest/googletest/ \
+    -DGTEST_INCLUDE_DIR=~/googletest_clone/googletest/googletest/include/ \
+    -DICU_UC_INCLUDE_DIR=/usr/local/Cellar/icu4c/XXX/include/ \
+    -DICU_UC_LIB=/usr/local/Cellar/icu4c/XXX/lib/libicuuc.dylib \
+    -DICU_I18N_INCLUDE_DIR=/usr/local/Cellar/icu4c/XXX/include/ \
+    -DICU_I18N_LIB=/usr/local/Cellar/icu4c/XXX/lib/libicui18n.dylib \
+    ..
+  $ make
+  $ ./libphonenumber_test
+
+Optional clean-up when done:
+  $ cd
+  $ rm -rf ~/libphonenumber_clone ~/googletest_clone
+
+  openssl is a dependency of wget and installed with it by Homebrew. If you had
+  openssl before installing wget don't uninstall here.
+  $ brew uninstall boost cmake icu4c openssl pkg-config protobuf wget
+
+  $ /usr/bin/ruby -e "$(curl -fsSL \
+    https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+
+  Homebrew will have changed permissions at installation. See output of previous
+  command for how to change them back, for example:
+  $ sudo chmod 0755 /usr/local
+  $ sudo chgrp wheel /usr/local
+
+
 Troubleshooting CMake via ccmake
 --------------------------------
   Follow these instructions if the build steps above don't work for you.
@@ -202,6 +258,7 @@ Troubleshooting CMake via ccmake
     $ cmake ..
     $ make
 
+
 Building the library on Windows (Visual Studio)
 -----------------------------------------------
 The library was tested with Visual Studio 2010.
@@ -263,6 +320,7 @@ As a result the library's headers and binaries should have been installed to
 C:/Program Files/libphonenumber/.
 Note that this path can be set by overriding the CMAKE_INSTALL_PREFIX variable
 with cmake-gui.
+
 
 Supported build parameters
 --------------------------

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: optional
 Maintainer: Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>
 Uploaders: Daniel Pocock <daniel@pocock.pro>, Fredrik Roubert <roubert@google.com>
 Build-Depends: cdbs,
-               cmake (>= 3.1),
+               cmake,
                debhelper (>= 9),
                default-jdk | java-sdk,
                libboost-dev (>= 1.40),


### PR DESCRIPTION
This is similar to the fix of #822.

Also update README to cover Mac installation.

This rolls back the cmake minimum version bump in #975 since it was
backwards-incompatible, and the following #984. Not expected to cause
any new user-facing regressions, but expected to solve any that were
introduced with #975.