### PR TITLE
Explicitly call std::stringstream::fail()

### DIFF
--- a/tools/cpp/src/cpp-build/generate_geocoding_data.cc
+++ b/tools/cpp/src/cpp-build/generate_geocoding_data.cc
@@ -141,7 +141,7 @@ bool StrToInt(const string& s, int32* n) {
   std::stringstream stream;
   stream << s;
   stream >> *n;
-  return stream;
+  return !stream.fail();
 }
 
 // Converts integer to string, returns true on success.
@@ -149,7 +149,7 @@ bool IntToStr(int32 n, string* s) {
   std::stringstream stream;
   stream << n;
   stream >> *s;
-  return stream;
+  return !stream.fail();
 }
 
 // Parses the prefix descriptions file at path, clears and fills the output


### PR DESCRIPTION
Implicit cast to bool does not work with C++11 and later. See http://en.cppreference.com/w/cpp/io/basic_ios/operator_bool