### PR TITLE
Repackage java protobuf library

### DIFF
--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -47,6 +47,14 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>libphonenumber.repackaged.com.google.protobuf</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -51,7 +51,8 @@
               <relocations>
                 <relocation>
                   <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>libphonenumber.repackaged.com.google.protobuf</shadedPattern>
+                  <shadedPattern>com.google.i18n.phonenumbers.repackaged.com.google.protobuf
+</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>


### PR DESCRIPTION
Repackage the Java `protobuf` library that is included in the libphonenumber source with a different package name to avoid conflicts with other projects.

A temporary workaround for #913, until [protobuf-javanano](http://mvnrepository.com/artifact/com.google.protobuf.nano/protobuf-javanano) is stable.

Contributed on behalf of @mingtaozhangsc.