### PR TITLE
Update 7.3.2 release notes

### DIFF
--- a/java/release_notes.txt
+++ b/java/release_notes.txt
@@ -1,11 +1,13 @@
 May 03, 2016: libphonenumber-7.3.2
+Code changes:
+ - Updated unit tests for Canada short numbers.
 Metadata changes:
  - Updated phone metadata for region code(s):
    AU, BR, ET, IN, KH, ML, NO, SB, TJ, US
  - Updated short number metadata for region code(s): CA, ML, US
- - New geocoding data for country calling code(s): 223 (en)
- - Updated geocoding data for country calling code(s): 
-   27 (en), 55 (en, pt), 1 (en)
+ - New geocoding data for country calling code(s):
+   55 (pt), 223 (en), 1548 (en), 1743 (en)
+ - Updated geocoding data for country calling code(s): 27 (en), 55 (en)
  - Updated carrier data for country calling code(s):
    61 (en), 91 (en), 223 (en), 251 (en), 677 (en), 992 (en)
 


### PR DESCRIPTION
1. Changing release notes back to what was automatically generated:

a. 55_pt was actually new this time (it was removed in a recent release): https://github.com/googlei18n/libphonenumber/commits/master/java/geocoder/src/com/google/i18n/phonenumbers/geocoding/data/55_pt

b. And we've always included the entire 1xxx numbers according to the file names - see libphonenumber-7.1.1 release notes for example.

We should generally leave the "metadata" section as is, and if it's wrong see why it was wrongly generated. Also if updating the release notes remember to update the PR description (https://github.com/googlei18n/libphonenumber/pull/1102 stayed the same).

2. Include the non-metadata change as "code changes", which slipped as it was added during the same PR as the release.