### PR TITLE
Fix parent of libphonenumber-parent Maven project

### DIFF
--- a/java/pending_code_changes.txt
+++ b/java/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Fixed parent of java/pom.xml, eliminating Maven build warning.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,9 +8,9 @@
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>com.google.i18n.phonenumbers</groupId>
+    <artifactId>libphonenumber-build-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <description>


### PR DESCRIPTION
Project structure is unstable, by default refers to ../pom.xml unless specified otherwise - so java/pom.xml was using pom.xml as the parent, and had the wrong groupId and artifactId (b/29343414).

Tested pom.xml changes by running `mvn package` inside java/ - everything builds successfully.