### PR TITLE
Fix Maven project hierarchy and plugin versions

### DIFF
--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -31,7 +31,7 @@
       <version>2.5</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -31,6 +31,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.2</version>
         <configuration>
           <excludes>
             <exclude>com/google/i18n/phonenumbers/SingleFileMetadataSourceImpl.class</exclude>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,9 +8,9 @@
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>com.google.i18n.phonenumbers</groupId>
+    <artifactId>libphonenumber-build-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <description>
@@ -92,7 +92,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.12</version>
         <configuration>
-          <forkMode>never</forkMode>
+          <forkCount>0</forkCount>
           <includes>
             <include>**/*Test.java</include>
           </includes>

--- a/tools/java/common/pom.xml
+++ b/tools/java/common/pom.xml
@@ -21,6 +21,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -31,6 +32,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/tools/java/cpp-build/pom.xml
+++ b/tools/java/cpp-build/pom.xml
@@ -25,6 +25,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -33,6 +34,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-source</id>
@@ -56,6 +58,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
+        <version>1.4.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -76,6 +79,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/tools/java/data/pom.xml
+++ b/tools/java/data/pom.xml
@@ -47,14 +47,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>net.kindleit</groupId>
-        <artifactId>maven-gae-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -79,13 +76,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <configuration>
-          <warSourceDirectory>webapp</warSourceDirectory>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.mortbay.jetty</groupId>

--- a/tools/java/java-build/pom.xml
+++ b/tools/java/java-build/pom.xml
@@ -43,6 +43,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -51,6 +52,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-source</id>


### PR DESCRIPTION
Fixes b/22840154 and b/29343414.
Tested by running `mvn package` from root.

Still have javadoc warnings and errors (b/29977680, b/27241869, b/27241398), but everything else is cleaned up with this change.

Does not check in changed generated jars because their generation is currently not hermetic and outdated anyway (b/29546716); the output would not change either as a result of the changes in this PR in `tools/java/cpp-build/pom.xml` and `tools/java/java-build/pom.xml`, these changes actually bring us closer to being hermetic (b/24799921).