### PR TITLE
Silence "unstable build" warnings from Maven

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,6 +11,7 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
+    <relativePath></relativePath>
   </parent>
 
   <description>


### PR DESCRIPTION
The reason I think this will work while the changes in https://github.com/googlei18n/libphonenumber/pull/1192 failed to deploy: this is the workaround at https://issues.apache.org/jira/browse/MNG-5146.

I'll release separately from metadata updates to e2e "test"/run this.
Fixes b/29343414.