### PR TITLE
Simplify concurrent metadata loading in MultiFileMetadataSourceImpl

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/MetadataLoader.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/MetadataLoader.java
@@ -23,7 +23,8 @@ import java.io.InputStream;
  */
 public interface MetadataLoader {
   /**
-   * Returns an input stream corresponding to the metadata to load.
+   * Returns an input stream corresponding to the metadata to load. This method may be invoked from
+   * several threads, so implementations should be stateless.
    *
    * @param metadataFileName File name (including path) of metadata to load. File path is an
    *     absolute class path like /com/google/i18n/phonenumbers/data/PhoneNumberMetadataProto.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/MetadataLoader.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/MetadataLoader.java
@@ -23,8 +23,8 @@ import java.io.InputStream;
  */
 public interface MetadataLoader {
   /**
-   * Returns an input stream corresponding to the metadata to load. This method may be invoked from
-   * several threads, so implementations should be stateless.
+   * Returns an input stream corresponding to the metadata to load. This method may be called
+   * concurrently so implementations must be thread-safe.
    *
    * @param metadataFileName File name (including path) of metadata to load. File path is an
    *     absolute class path like /com/google/i18n/phonenumbers/data/PhoneNumberMetadataProto.

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
@@ -100,9 +100,9 @@ final class MultiFileMetadataSourceImpl implements MetadataSource {
 
   /**
    * @param key             The geographical region code or the non-geographical region's country
-                            calling code.
+   *                        calling code.
    * @param map             The map to contain the mapping from {@code key} to the corresponding
-                            metadata.
+   *                        metadata.
    * @param filePrefix      The prefix of the metadata files from which region data is loaded.
    * @param metadataLoader  The metadata loader used to inject alternative metadata sources.
    */
@@ -114,13 +114,11 @@ final class MultiFileMetadataSourceImpl implements MetadataSource {
     String fileName = filePrefix + "_" + key;
     InputStream source = metadataLoader.loadMetadata(fileName);
     if (source == null) {
-      logger.log(Level.SEVERE, "missing metadata: " + fileName);
       throw new IllegalStateException("missing metadata: " + fileName);
     }
     PhoneMetadataCollection metadataCollection = loadMetadataAndCloseInput(source);
     PhoneMetadata[] metadataList = metadataCollection.metadata;
     if (metadataList.length == 0) {
-      logger.log(Level.SEVERE, "empty metadata: " + fileName);
       throw new IllegalStateException("empty metadata: " + fileName);
     }
     if (metadataList.length > 1) {
@@ -146,7 +144,6 @@ final class MultiFileMetadataSourceImpl implements MetadataSource {
           new ObjectInputStream(source), MULTI_FILE_BUFFER_SIZE));
       return metadataCollection;
     } catch (IOException e) {
-      logger.log(Level.SEVERE, "cannot load/parse metadata", e);
       throw new RuntimeException("cannot load/parse metadata", e);
     } finally {
       try {

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/MultiFileMetadataSourceImpl.java
@@ -82,18 +82,26 @@ final class MultiFileMetadataSourceImpl implements MetadataSource {
       return loadMetadataFromFile(
           countryCallingCode, countryCodeToNonGeographicalMetadataMap, filePrefix, metadataLoader);
     }
+    // The given country calling code was non-geographic, so we return null.
     return null;
   }
 
+  // A country calling code is non-geographic if it only maps to the non-geographical region code.
   private boolean isNonGeographicalCountryCallingCode(int countryCallingCode) {
     List<String> regionCodes =
         CountryCodeToRegionCodeMap.getCountryCodeToRegionCodeMap().get(countryCallingCode);
-    // A country calling code is non-geographic if it only maps to the non-geographical region code.
-    return (regionCodes.size() == 1 &&
-        PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY.equals(regionCodes.get(0)));
+    return (regionCodes.size() == 1
+        && PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY.equals(regionCodes.get(0)));
   }
 
-  // @param key  The geographical region code or non-geographical region's country calling code.
+  /**
+   * @param key             The geographical region code or non-geographical region's country
+                            calling code.
+   * @param map             The map to contain the mapping from {@code key} to the corresponding
+                            metadata.
+   * @param filePrefix      The prefix of the metadata files from which region data is loaded.
+   * @param metadataLoader  The metadata loader used to inject alternative metadata sources.
+   */
   // @VisibleForTesting
   static <T> PhoneMetadata loadMetadataFromFile(
       T key, ConcurrentHashMap<T, PhoneMetadata> map, String filePrefix,

--- a/java/pending_code_changes.txt
+++ b/java/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Make metadata loading thread-safe in MultiFileMetadataSourceImpl.

--- a/java/pending_code_changes.txt
+++ b/java/pending_code_changes.txt
@@ -1,2 +1,3 @@
 Code changes:
- - Make metadata loading thread-safe in MultiFileMetadataSourceImpl.
+ - Simplify concurrent metadata loading in MultiFileMetadataSourceImpl and
+   reduce points of contention.


### PR DESCRIPTION
Also removes point of contention for getting metadata when it's already been loaded.

b/30156489, b/24455712, b/30158468