### PR TITLE
Updated ZA carrier codes for numbers in the 27625-27647 range.

### DIFF
--- a/resources/carrier/en/27.txt
+++ b/resources/carrier/en/27.txt
@@ -14,8 +14,9 @@
 #
 # The carrier prefixes were added according to the Wikipedia page
 # http://en.wikipedia.org/wiki/Telephone_numbers_in_South_Africa
-# and the open-source bug
+# and the open-source bugs
 # https://github.com/googlei18n/libphonenumber/issues/489
+# https://github.com/googlei18n/libphonenumber/issues/1242
 
 27603|MTN
 27604|MTN
@@ -39,6 +40,29 @@
 27622|Cell C
 27623|Cell C
 27624|Cell C
+27625|Cell C
+27626|Cell C
+27627|Cell C
+27628|Cell C
+27629|Cell C
+27630|MTN
+27631|MTN
+27632|MTN
+27633|MTN
+27634|MTN
+27635|MTN
+27636|Vodacom
+27637|Vodacom
+27638|MTN
+27639|MTN
+27640|MTN
+27641|Cell C
+27642|Cell C
+27643|Cell C
+27644|Cell C
+27645|Cell C
+27646|Vodacom
+27647|Vodacom
 27710|MTN
 27711|Vodacom
 27712|Vodacom


### PR DESCRIPTION
Updated +27 carrier data mappings with the information provided by the South African Mobile portability company issue : https://github.com/googlei18n/libphonenumber/issues/1242