### PR TITLE
Change Maven parent of libphonenumber-parent artifact

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,9 +8,9 @@
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>com.google.i18n.phonenumbers</groupId>
+    <artifactId>libphonenumber-build-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <description>


### PR DESCRIPTION
This change results in a build success for these calls from the root directory:

```
ant -f java/build.xml \
    build-phone-metadata build-test-metadata \
    build-short-metadata build-alternate-metadata \
    build-timezones-data build-timezones-test-data \
    junit
mvn package
mvn install
```

Yet when we got to deployment last time, we failed. Sending a PR to see whether Travis would catch this.