### PR TITLE
add OSGi meta-data to libphonenumber and geocoder

### DIFF
--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -38,26 +38,6 @@
     </testResources>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <instructions>
-            <Export-Package>com.google.i18n.phonenumbers.geocoding</Export-Package>
-            <Private-Package>com.google.i18n.phonenumbers.geocoding.data</Private-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.15</version>

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -38,6 +38,24 @@
     </testResources>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Export-Package>com.google.i18n.phonenumbers.geocoding</Export-Package>
+            <Private-Package>com.google.i18n.phonenumbers.geocoding.data</Private-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.15</version>

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -40,6 +40,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <instructions>
             <Export-Package>com.google.i18n.phonenumbers.geocoding</Export-Package>
@@ -49,6 +50,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -36,7 +36,6 @@
         <configuration>
           <instructions>
             <Export-Package>com.google.i18n.phonenumbers</Export-Package>
-            <Private-Package>com.google.i18n.phonenumbers.data</Private-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -32,6 +32,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <instructions>
             <Export-Package>com.google.i18n.phonenumbers</Export-Package>
@@ -41,6 +42,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -30,6 +30,24 @@
     </testResources>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Export-Package>com.google.i18n.phonenumbers</Export-Package>
+            <Private-Package>com.google.i18n.phonenumbers.data</Private-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.15</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -86,6 +86,24 @@
   </modules>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.2.0</version>
+          <executions>
+            <execution>
+              <id>bundle-manifest</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This takes the patch submitted for #205 and modifies it to be a bit less intrusive with how it adds the OSGi meta-data.

This patch follows the mechanism described here: http://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#adding-osgi-metadata-to-existing-projects-without-changing-the-packaging-type

How this works is that the `maven-bundle-plugin` is used to generate a `MANIFEST.MF` containing the necessary OSGi meta-data at build time, then the `maven-jar-plugin` is configured to utilize this built `MANIFEST.MF` file instead of generating it's own, everything else about the build process is left untouched.