### PR TITLE
Add convenience instructions to quickly update Phonemetadata.java

### DIFF
--- a/java/lib/protobuf-javanano-readme.md
+++ b/java/lib/protobuf-javanano-readme.md
@@ -1,4 +1,36 @@
-Steps to update the protobuf library version:
+# How to regenerate `Phonemetadata.java`
+
+You need to re-generate
+`java/libphonenumber/src/com/google/i18n/phonenumbers/nano/Phonemetadata.java` if you update
+`resources/phonemetadata.proto` or the protobuf version.
+
+Here are convenience instructions to update `Phonemetadata.java`.
+
+Checklist:
+
+- Are we still depending on Maven's 3.0.0-alpha-7 version of com.google.protobuf.nano
+  protobuf-javanano?
+- Are you on a Linux x86_64 architecture? Check via the `arch` command in your terminal.
+
+If you answered no to any question, refer instead to the full instructions, [How to update the
+protobuf version](#how-to-update-the-protobuf-version).
+
+```
+mkdir /tmp/custom_protoc/ && \
+cd /tmp/custom_protoc/ && \
+wget https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip && \
+unzip protoc-3.0.0-beta-4-linux-x86_64.zip
+```
+
+Then go to the root of your libphonenumber git repository and run:
+
+```
+/tmp/custom_protoc/bin/protoc --javanano_out=java/libphonenumber/src \
+  resources/phonemetadata.proto \
+  --proto_path=resources
+```
+
+# How to update the protobuf version
 
 - Start by finding a protobuf library version released to Maven Central that has functionality you
   need, e.g. nano. See http://mvnrepository.com/artifact/com.google.protobuf.
@@ -18,3 +50,5 @@ Steps to update the protobuf library version:
          resources/phonemetadata.proto \
          --proto_path=resources
   ```
+- Update the convenience instructions, [How to regenerate `Phonemetadata.java`]
+  (#how-to-regenerate-phonemetadatajava).


### PR DESCRIPTION
To help with #1308 :)
We need to automate this generation at some point. b/31288274

Tested: Deleted `Phonemetadata.java` in a local git repository synced to master head, ran the 2 commands, and got back to exactly the original state.