### PR TITLE
Stop JSON serialization from setting what should be empty fields

### DIFF
--- a/tools/java/java-build/src/com/google/i18n/phonenumbers/BuildMetadataJsonFromXml.java
+++ b/tools/java/java-build/src/com/google/i18n/phonenumbers/BuildMetadataJsonFromXml.java
@@ -197,19 +197,22 @@ public class BuildMetadataJsonFromXml extends Command {
       jsArrayBuilder.append(null);
     }
     // optional string national_prefix_formatting_rule = 4;
-    if (format.hasNationalPrefixFormattingRule()) {
+    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    if (format.getNationalPrefixFormattingRule().length() > 0) {
       jsArrayBuilder.append(format.getNationalPrefixFormattingRule());
     } else {
       jsArrayBuilder.append(null);
     }
     // optional string domestic_carrier_code_formatting_rule = 5;
-    if (format.hasDomesticCarrierCodeFormattingRule()) {
+    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    if (format.getDomesticCarrierCodeFormattingRule().length() > 0) {
       jsArrayBuilder.append(format.getDomesticCarrierCodeFormattingRule());
     } else {
       jsArrayBuilder.append(null);
     }
     // optional bool national_prefix_optional_when_formatting = 6;
-    if (format.hasNationalPrefixOptionalWhenFormatting()) {
+    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    if (format.isNationalPrefixOptionalWhenFormatting()) {
       jsArrayBuilder.append(format.isNationalPrefixOptionalWhenFormatting());
     } else {
       jsArrayBuilder.append(null);
@@ -289,7 +292,8 @@ public class BuildMetadataJsonFromXml extends Command {
       jsArrayBuilder.append(null);
     }
     // optional string international_prefix = 11;
-    if (metadata.hasInternationalPrefix()) {
+    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    if (metadata.getInternationalPrefix().length() > 0) {
       jsArrayBuilder.append(metadata.getInternationalPrefix());
     } else {
       jsArrayBuilder.append(null);

--- a/tools/java/java-build/src/com/google/i18n/phonenumbers/BuildMetadataJsonFromXml.java
+++ b/tools/java/java-build/src/com/google/i18n/phonenumbers/BuildMetadataJsonFromXml.java
@@ -197,21 +197,21 @@ public class BuildMetadataJsonFromXml extends Command {
       jsArrayBuilder.append(null);
     }
     // optional string national_prefix_formatting_rule = 4;
-    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    // TODO: Don't set in format if default to begin with, and replace this check with "has".
     if (format.getNationalPrefixFormattingRule().length() > 0) {
       jsArrayBuilder.append(format.getNationalPrefixFormattingRule());
     } else {
       jsArrayBuilder.append(null);
     }
     // optional string domestic_carrier_code_formatting_rule = 5;
-    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    // TODO: Don't set in format if default to begin with, and replace this check with "has".
     if (format.getDomesticCarrierCodeFormattingRule().length() > 0) {
       jsArrayBuilder.append(format.getDomesticCarrierCodeFormattingRule());
     } else {
       jsArrayBuilder.append(null);
     }
     // optional bool national_prefix_optional_when_formatting = 6;
-    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    // TODO: Don't set in format if default to begin with, and replace this check with "has".
     if (format.isNationalPrefixOptionalWhenFormatting()) {
       jsArrayBuilder.append(format.isNationalPrefixOptionalWhenFormatting());
     } else {
@@ -292,7 +292,7 @@ public class BuildMetadataJsonFromXml extends Command {
       jsArrayBuilder.append(null);
     }
     // optional string international_prefix = 11;
-    // TODO: Don't set in format if empty to begin with, and replace this check with "has".
+    // TODO: Don't set in format if default to begin with, and replace this check with "has".
     if (metadata.getInternationalPrefix().length() > 0) {
       jsArrayBuilder.append(metadata.getInternationalPrefix());
     } else {


### PR DESCRIPTION
Long-term we should fix the code that's setting these fields and remove
this workaround.
b/31541333