### PR TITLE
Match short numbers in text

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -466,7 +466,8 @@ public class PhoneNumberUtil {
     POSSIBLE {
       @Override
       boolean verify(PhoneNumber number, String candidate, PhoneNumberUtil util) {
-        return util.isPossibleNumber(number);
+        ShortNumberInfo shortInfo = ShortNumberInfo.getInstance();
+        return (util.isPossibleNumber(number) || shortInfo.isPossibleShortNumber(number));
       }
     },
     /**
@@ -478,7 +479,8 @@ public class PhoneNumberUtil {
     VALID {
       @Override
       boolean verify(PhoneNumber number, String candidate, PhoneNumberUtil util) {
-        if (!util.isValidNumber(number)
+        ShortNumberInfo shortInfo = ShortNumberInfo.getInstance();
+        if (!(util.isValidNumber(number) || shortInfo.isValidShortNumber(number))
             || !PhoneNumberMatcher.containsOnlyValidXChars(number, candidate, util)) {
           return false;
         }
@@ -500,7 +502,8 @@ public class PhoneNumberUtil {
     STRICT_GROUPING {
       @Override
       boolean verify(PhoneNumber number, String candidate, PhoneNumberUtil util) {
-        if (!util.isValidNumber(number)
+        ShortNumberInfo shortInfo = ShortNumberInfo.getInstance();
+        if (!(util.isValidNumber(number) || shortInfo.isValidShortNumber(number))
             || !PhoneNumberMatcher.containsOnlyValidXChars(number, candidate, util)
             || PhoneNumberMatcher.containsMoreThanOneSlashInNationalNumber(number, candidate)
             || !PhoneNumberMatcher.isNationalPrefixPresentIfRequired(number, util)) {
@@ -532,7 +535,8 @@ public class PhoneNumberUtil {
     EXACT_GROUPING {
       @Override
       boolean verify(PhoneNumber number, String candidate, PhoneNumberUtil util) {
-        if (!util.isValidNumber(number)
+        ShortNumberInfo shortInfo = ShortNumberInfo.getInstance();
+        if (!(util.isValidNumber(number) || shortInfo.isValidShortNumber(number))
             || !PhoneNumberMatcher.containsOnlyValidXChars(number, candidate, util)
             || PhoneNumberMatcher.containsMoreThanOneSlashInNationalNumber(number, candidate)
             || !PhoneNumberMatcher.isNationalPrefixPresentIfRequired(number, util)) {


### PR DESCRIPTION
FindNumbers isn't currently able to find short numbers, which is a reasonable
expectation from it.

This patch changes the way phone numbers are verified, checking not only if
they are possible/valid numbers but also if they're possible/valid short
numbers.

Closes: #442