### PR TITLE
Update release tag to vX.Y.Z

### DIFF
--- a/java/pending_code_changes.txt
+++ b/java/pending_code_changes.txt
@@ -1,3 +1,6 @@
+GitHub project changes:
+ - Changed tag to vX.Y.Z from libphonenumber-X.Y.Z; this affects porters and
+   derived projects.
 Code changes:
  - Using new possibleLengthInfo to decide whether a short number is the right
    length or not. This could result in more specific results; whereas before, a

--- a/java/pending_code_changes.txt
+++ b/java/pending_code_changes.txt
@@ -1,5 +1,5 @@
 GitHub project changes:
- - Changed tag to vX.Y.Z from libphonenumber-X.Y.Z; this affects porters and
+ - Changed tag to vX.Y.Z from libphonenumber-X.Y.Z; this may affect ports and
    derived projects.
 Code changes:
  - Using new possibleLengthInfo to decide whether a short number is the right

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -146,7 +146,7 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.2.1</version>
         <configuration>
-          <tagNameFormat>libphonenumber-@{project.version}</tagNameFormat>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Change tag format as requested in https://github.com/googlei18n/libphonenumber/issues/1362

Tested:
Running mvn locally gives the existing jar naming format, so the Maven Central jars are not expected to change:
```
carrier-1.47-SNAPSHOT.jar
carrier-1.47-SNAPSHOT-javadoc.jar
carrier-1.47-SNAPSHOT-sources.jar
demo-7.7.4-SNAPSHOT.jar
demo-7.7.4-SNAPSHOT-javadoc.jar
demo-7.7.4-SNAPSHOT-sources.jar
geocoder-2.57-SNAPSHOT.jar
geocoder-2.57-SNAPSHOT-javadoc.jar
geocoder-2.57-SNAPSHOT-sources.jar
prefixmapper-2.57-SNAPSHOT.jar
prefixmapper-2.57-SNAPSHOT-javadoc.jar
prefixmapper-2.57-SNAPSHOT-sources.jar
libphonenumber-7.7.4-SNAPSHOT.jar
libphonenumber-7.7.4-SNAPSHOT-javadoc.jar
libphonenumber-7.7.4-SNAPSHOT-sources.jar
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1409)
<!-- Reviewable:end -->
