### PR TITLE
Update Brazil carrier selection codes used for dialling long-distance (BR, +55)

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -185,7 +185,7 @@
           <leadingDigits>[2-4679][2-8]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
-        <numberFormat pattern="(5[0256])(\d{3})(\d{4})">
+        <numberFormat pattern="(5\d)(\d{3})(\d{4})">
           <leadingDigits>5</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -213,8 +213,9 @@
         <possibleNumberPattern>\d{7,8}</possibleNumberPattern>
         <exampleNumber>22345678</exampleNumber>
       </fixedLine>
+      <!-- Added 9 digit 54 range to mobile as per online evidences. -->
       <mobile>
-        <nationalNumberPattern>5[0256]\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>5[024-6]\d{7}</nationalNumberPattern>
         <possibleNumberPattern>\d{9}</possibleNumberPattern>
         <exampleNumber>501234567</exampleNumber>
       </mobile>
@@ -3317,7 +3318,7 @@
     <territory id="BR" countryCode="55"
                internationalPrefix="00(?:1[245]|2[1-35]|31|4[13]|[56]5|99)"
                nationalPrefix="0"
-               nationalPrefixForParsing="0(?:(1[245]|2[1-35]|31|4[13]|[56]5|99)(\d{10,11}))?"
+               nationalPrefixForParsing="0(?:(1[2-8]|2[13-7]|3[146]|4[1569]|5[368]|6[1-58]|7[1-68]|8[1257]|9[158])(\d{10,11}))?"
                nationalPrefixTransformRule="$2" mobileNumberPortableRegion="true">
       <references>
         <sourceUrl>http://en.wikipedia.org/wiki/%2B55</sourceUrl>
@@ -3362,9 +3363,10 @@
             carrierCodeFormattingRule="$NP $CC ($FG)">
           <leadingDigits>
             (?:
-              [1689][1-9]|
+              [14689][1-9]|
               2[12478]|
               3[1-578]|
+              5[13-5]|
               7[13-579]
             )9
           </leadingDigits>
@@ -3396,8 +3398,7 @@
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
-          [1-46-9]\d{7,10}|
-          5\d{8,9}
+          [1-9]\d{7,10}
         </nationalNumberPattern>
         <possibleNumberPattern>\d{8,11}</possibleNumberPattern>
       </generalDesc>
@@ -3435,25 +3436,24 @@
              The following pattern is divided into 3 sections: ranges for which the migration is
              complete, ranges which are in transition, and ranges which are still in the old format.
              Generally we keep ranges in transition until a few months after we are notified that
-             they are not in use (b/28458993). -->
+             they are not in use (b/28458993).
+        -->
         <nationalNumberPattern>
-          1[1-9](?:
+          (?:[1689][1-9]|
+          2[12478]|
+          3[1-578]|
+          7[13-579]
+          )(?:
             7|
             9\d
           )\d{7}|
           (?:
-            2[12478]|
-            3[1-578]|
-            [689][1-9]|
-            7[13-579]
+          4[1-9]|
+          5[13-5]
           )(?:
             [6-8]|
             9\d?
-          )\d{7}|
-          (?:
-            4[1-9]|
-            5[1-5]
-          )[6-9]\d{7}
+          )\d{7}
         </nationalNumberPattern>
         <possibleNumberPattern>\d{10,11}</possibleNumberPattern>
         <exampleNumber>11961234567</exampleNumber>
@@ -3989,7 +3989,20 @@
         <possibleNumberPattern>\d{7}(?:\d{4})?</possibleNumberPattern>
       </generalDesc>
       <fixedLine>
-        <nationalNumberPattern>[234578][02]\d{5}</nationalNumberPattern>
+        <!-- Wikipedia and ITU seem out of date, but say that for a number in the format ZNY-XXXX
+             Z represents the district code (or 6 for mobile), N the type of number and Y the first
+             digit of the customer's number. Only N = 0 and 2 are supposedly in use, but we have
+             found many numbers starting with 732 online. No evidence has been found about the
+             category of 732 numbers. -->
+        <nationalNumberPattern>
+          (?:
+            [23458][02]\d|
+            7(?:
+              [02]\d|
+              32
+            )
+          )\d{4}
+        </nationalNumberPattern>
         <possibleNumberPattern>\d{7}</possibleNumberPattern>
         <exampleNumber>2221234</exampleNumber>
       </fixedLine>
@@ -9190,6 +9203,7 @@
               [079]7|
               2[0167]|
               3[45]|
+              47|
               8[789]
             )|
             8(?:
@@ -9240,6 +9254,7 @@
               [079]7|
               2[0167]|
               3[45]|
+              47|
               8[789]
             )|
             8(?:
@@ -10601,7 +10616,7 @@
                 1[07-9]|
                 2[015-8]|
                 3[17-9]|
-                4[789]|
+                4[017-9]|
                 9[01689]
               )|
               4(?:
@@ -10690,7 +10705,10 @@
                   [01][089]
                 )|
                 3[17-9]|
-                4[789]|
+                4(?:
+                  [07-9]|
+                  11
+                )|
                 9[01689]
               )|
               4(?:
@@ -11170,7 +11188,10 @@
                   [01][089]
                 )|
                 3[17-9]\d|
-                4[789]\d|
+                4(?:
+                  [07-9]\d|
+                  11
+                )|
                 9[01689]\d
               )|
               4(?:
@@ -13963,7 +13984,7 @@
             1(?:
               5[46-9]|
               6[04678]|
-              8[0579]
+              8[03579]
             )
           </leadingDigits>
           <leadingDigits>
@@ -13984,6 +14005,7 @@
               )|
               8(?:
                 00|
+                33|
                 55|
                 77|
                 99
@@ -14081,6 +14103,7 @@
             )|
             8(?:
               00|
+              33|
               55|
               77|
               99


### PR DESCRIPTION
* adjust for carrier codes (CSP in portuguese), based on anatel site 
http://sistemas.anatel.gov.br/stel/Consultas/STFC/PrestadorasCSP/tela.asp?nav=3&c=1&pref=
* prepare for 9th digit in cellphones from south region
http://www.anatel.gov.br/institucional/component/content/article?id=1385

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1416)
<!-- Reviewable:end -->
