### PR TITLE
[RU] Fix `nationalPrefixForParsing` and `nationalPrefixTransformRule`

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -21391,7 +21391,9 @@
     <territory id="RU" countryCode="7" mainCountryForCode="true" preferredInternationalPrefix="8~10"
                internationalPrefix="810" nationalPrefix="8"
                nationalPrefixFormattingRule="$NP ($FG)"
-               nationalPrefixOptionalWhenFormatting="true" >
+               nationalPrefixOptionalWhenFormatting="true"
+               nationalPrefixForParsing="8?(\\d{10})"
+               nationalPrefixTransformRule="$1">
       <references>
         <sourceUrl>http://www.itu.int/oth/T02020000AD/en</sourceUrl>
         <sourceUrl>http://en.wikipedia.org/wiki/%2B7</sourceUrl>


### PR DESCRIPTION
Fixes #1447

Fixes `nationalPrefixForParsing` and `nationalPrefixTransformRule` for Russia.

I'm Russian.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1448)
<!-- Reviewable:end -->
