### PR TITLE
Update PhoneNumberMetadata.xml

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -15206,7 +15206,7 @@
              determining the country is faster. -->
         <nationalNumberPattern>
           (?:
-            33\d|
+            6\d{2}|
             7\d{2}|
             80[09]
           )\d{7}


### PR DESCRIPTION
For Kazakhstan: 

> Under an agreement with Russia on 11 June 2006, Kazakhstan is assigned zone codes 6xx and 7xx (x = 0 to 9) under the unified plan. Land lines are in geographic zone codes from 710 to 729, mobiles are in zone codes 70x and 77x, and other services are in 75x and 76x.[1] Previously, land lines used zone codes in the 3xx range. As zone codes 3xx are assigned to Russia, zone codes 3xx in Kazakhstan were changed by substituting the leading '3' with '7'.

https://en.wikipedia.org/wiki/Telephone_numbers_in_Kazakhstan
http://www.itu.int/dms_pub/itu-t/oth/02/02/T020200006F0001PDFE.pdf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1461)
<!-- Reviewable:end -->
