### PR TITLE
Fix Israel national 079 numbers

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -11023,7 +11023,7 @@
               77|
               81
             )|
-            9[29]\d
+            9[2-9]\d
           )\d{5}
         </nationalNumberPattern>
         <possibleNumberPattern>\d{9}</possibleNumberPattern>


### PR DESCRIPTION
Fix Israel national 079 numbers to match all legal numbers starting with 079. Examples of numbers not in old version:
0792 Free Telecom
0795 Hallo
0797 Cellact

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1496)
<!-- Reviewable:end -->
