### PR TITLE
Adding more StrCat helper methods with more args

### DIFF
--- a/cpp/src/phonenumbers/phonenumbermatcher.cc
+++ b/cpp/src/phonenumbers/phonenumbermatcher.cc
@@ -219,10 +219,6 @@ class PhoneNumberMatcherRegExps : public Singleton<PhoneNumberMatcherRegExps> {
   string lead_class_chars_;
   // Same as lead_class_chars_, but enclosed as a character class.
   string lead_class_;
-  // Extra helper strings that form part of pattern_. These are stored
-  // separately since StrCat has a limit of 12 args.
-  string opening_punctuation_;
-  string optional_extn_pattern_;
 
  public:
   // We use two different reg-ex factories here for performance reasons. RE2 is
@@ -287,11 +283,6 @@ class PhoneNumberMatcherRegExps : public Singleton<PhoneNumberMatcherRegExps> {
         digit_sequence_(StrCat("\\p{Nd}", Limit(1, digit_block_limit_))),
         lead_class_chars_(StrCat(opening_parens_, PhoneNumberUtil::kPlusChars)),
         lead_class_(StrCat("[", lead_class_chars_, "]")),
-        opening_punctuation_(StrCat("(?:", lead_class_, punctuation_, ")")),
-        optional_extn_pattern_(StrCat(
-            "(?i)(?:",
-            PhoneNumberUtil::GetInstance()->GetExtnPatternsForMatching(),
-            ")?")),
         regexp_factory_for_pattern_(new ICURegExpFactory()),
 #ifdef I18N_PHONENUMBERS_USE_RE2
         regexp_factory_(new RE2RegExpFactory()),
@@ -317,9 +308,11 @@ class PhoneNumberMatcherRegExps : public Singleton<PhoneNumberMatcherRegExps> {
             regexp_factory_->CreateRegExp("(\\d+)")),
         lead_class_pattern_(regexp_factory_->CreateRegExp(lead_class_)),
         pattern_(regexp_factory_for_pattern_->CreateRegExp(
-            StrCat("(", opening_punctuation_, lead_limit_,
+            StrCat("((?:", lead_class_, punctuation_, ")", lead_limit_,
                    digit_sequence_, "(?:", punctuation_, digit_sequence_, ")",
-                   block_limit_, optional_extn_pattern_, ")"))) {
+                   block_limit_, "(?i)(?:",
+                   PhoneNumberUtil::GetInstance()->GetExtnPatternsForMatching(),
+                   ")?)"))) {
     inner_matches_->push_back(
         // Breaks on the slash - e.g. "651-234-2345/332-445-1234"
         regexp_factory_->CreateRegExp("/+(.*)"));

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -422,11 +422,6 @@ class PhoneNumberRegExpsAndMappings {
         geo_mobile_countries_without_mobile_area_codes_.end());
   }
 
-  // Small string helpers since StrCat has a maximum number of arguments. These
-  // are both used to build valid_phone_number_.
-  const string punctuation_and_star_sign_;
-  const string min_length_phone_number_pattern_;
-
   // Regular expression of viable phone numbers. This is location independent.
   // Checks we have at least three leading digits, and only valid punctuation,
   // alpha characters and digits in the phone number. Does not include extension
@@ -556,17 +551,12 @@ class PhoneNumberRegExpsAndMappings {
   scoped_ptr<const RegExp> plus_chars_pattern_;
 
   PhoneNumberRegExpsAndMappings()
-      : punctuation_and_star_sign_(StrCat(PhoneNumberUtil::kValidPunctuation,
-                                          kStarSign)),
-        min_length_phone_number_pattern_(
-            StrCat(kDigits, "{", PhoneNumberUtil::kMinLengthForNsn, "}")),
-        valid_phone_number_(
-            StrCat(min_length_phone_number_pattern_, "|[",
+      : valid_phone_number_(
+            StrCat(kDigits, "{", PhoneNumberUtil::kMinLengthForNsn, "}|[",
                    PhoneNumberUtil::kPlusChars, "]*(?:[",
-                   punctuation_and_star_sign_, "]*",
-                   kDigits, "){3,}[", kValidAlpha,
-                   punctuation_and_star_sign_, kDigits,
-                   "]*")),
+                   PhoneNumberUtil::kValidPunctuation, kStarSign, "]*",
+                   kDigits, "){3,}[", PhoneNumberUtil::kValidPunctuation,
+                   kStarSign, kValidAlpha, kDigits, "]*")),
         extn_patterns_for_parsing_(
             CreateExtnPattern(StrCat(",;", kSingleExtnSymbolsForMatching))),
         regexp_factory_(new RegExpFactory()),

--- a/cpp/src/phonenumbers/stringutil.cc
+++ b/cpp/src/phonenumbers/stringutil.cc
@@ -391,6 +391,130 @@ string StrCat(const StringHolder& s1, const StringHolder& s2,
   return result;
 }
 
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13) {
+  string result;
+  result.reserve(s1.Length() + s2.Length()  + s3.Length() + s4.Length() +
+                 s5.Length() + s6.Length()  + s7.Length() + s8.Length() +
+                 s9.Length() + s10.Length() + s11.Length() + s12.Length() +
+                 s13.Length());
+  result += s1;
+  result += s2;
+  result += s3;
+  result += s4;
+  result += s5;
+  result += s6;
+  result += s7;
+  result += s8;
+  result += s9;
+  result += s10;
+  result += s11;
+  result += s12;
+  result += s13;
+
+  return result;
+}
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14) {
+  string result;
+  result.reserve(s1.Length() + s2.Length()  + s3.Length() + s4.Length() +
+                 s5.Length() + s6.Length()  + s7.Length() + s8.Length() +
+                 s9.Length() + s10.Length() + s11.Length() + s12.Length() +
+                 s13.Length() + s14.Length());
+  result += s1;
+  result += s2;
+  result += s3;
+  result += s4;
+  result += s5;
+  result += s6;
+  result += s7;
+  result += s8;
+  result += s9;
+  result += s10;
+  result += s11;
+  result += s12;
+  result += s13;
+  result += s14;
+
+  return result;
+}
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14,
+              const StringHolder& s15) {
+  string result;
+  result.reserve(s1.Length() + s2.Length()  + s3.Length() + s4.Length() +
+                 s5.Length() + s6.Length()  + s7.Length() + s8.Length() +
+                 s9.Length() + s10.Length() + s11.Length() + s12.Length() +
+                 s13.Length() + s14.Length() + s15.Length());
+  result += s1;
+  result += s2;
+  result += s3;
+  result += s4;
+  result += s5;
+  result += s6;
+  result += s7;
+  result += s8;
+  result += s9;
+  result += s10;
+  result += s11;
+  result += s12;
+  result += s13;
+  result += s14;
+  result += s15;
+
+  return result;
+}
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14,
+              const StringHolder& s15, const StringHolder& s16) {
+  string result;
+  result.reserve(s1.Length() + s2.Length()  + s3.Length() + s4.Length() +
+                 s5.Length() + s6.Length()  + s7.Length() + s8.Length() +
+                 s9.Length() + s10.Length() + s11.Length() + s12.Length() +
+                 s13.Length() + s14.Length() + s15.Length() + s16.Length());
+  result += s1;
+  result += s2;
+  result += s3;
+  result += s4;
+  result += s5;
+  result += s6;
+  result += s7;
+  result += s8;
+  result += s9;
+  result += s10;
+  result += s11;
+  result += s12;
+  result += s13;
+  result += s14;
+  result += s15;
+  result += s16;
+
+  return result;
+}
+
 // StrAppend
 
 void StrAppend(string* dest, const StringHolder& s1) {

--- a/cpp/src/phonenumbers/stringutil.h
+++ b/cpp/src/phonenumbers/stringutil.h
@@ -156,6 +156,40 @@ string StrCat(const StringHolder& s1, const StringHolder& s2,
               const StringHolder& s9, const StringHolder& s10,
               const StringHolder& s11, const StringHolder& s12);
 
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13);
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14);
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14,
+              const StringHolder& s15);
+
+string StrCat(const StringHolder& s1, const StringHolder& s2,
+              const StringHolder& s3, const StringHolder& s4,
+              const StringHolder& s5, const StringHolder& s6,
+              const StringHolder& s7, const StringHolder& s8,
+              const StringHolder& s9, const StringHolder& s10,
+              const StringHolder& s11, const StringHolder& s12,
+              const StringHolder& s13, const StringHolder& s14,
+              const StringHolder& s15, const StringHolder& s16);
+
 void StrAppend(string* dest, const StringHolder& s1);
 
 void StrAppend(string* dest, const StringHolder& s1, const StringHolder& s2);


### PR DESCRIPTION
Refactoring change:
Adding more StrCat helper methods with more args to remove some temp vars in the phonenumbermatcher and phonenumberutil that were there to work around this restriction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1543)
<!-- Reviewable:end -->
