### PR TITLE
Add std=c++11 to CMakeLists for older compilers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -333,6 +333,8 @@ if (${USE_ICU_REGEXP} STREQUAL "ON")
   endif ()
 endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 if (NOT WIN32)
   add_definitions ("-Wall -Werror")
 endif ()


### PR DESCRIPTION
Compiling the library with older compilers like gcc 4.9 that do not compile the code with the C++11 standard by default may cause errors. Therefore I created this pull request that adds the C++11 standard explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1594)
<!-- Reviewable:end -->
