### PR TITLE
Update typos in old release notes

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1042,12 +1042,12 @@ Sep 17, 2012: libphonenumber-5.1.3
  - Updated metadata for non-geographical calling codes: 800, 808, 888, 979
  - Updated geocoding data for country calling code(s): 98 (en), 1 (en)
 
-Sep 11, 2010: libphonenumber-5.1.2
+Sep 11, 2012: libphonenumber-5.1.2
 * Bug fix:
  - Fixing regression in AsYouTypeFormatter where it no longer worked for numbers entered in national
    format for countries with no national prefix, e.g. Spain.
 
-Sep 5, 2010: libphonenumber-5.1.1
+Sep 5, 2012: libphonenumber-5.1.1
 * Code changes:
   - Added better logging/exception handling for catching cases where metadata is invalid/missing.
 


### PR DESCRIPTION
Two releases in 2012 were labeled as 2010.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1606)
<!-- Reviewable:end -->
