### PR TITLE
Improve visibility for method: hasValidCountryCallingCode

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -1060,7 +1060,7 @@ public class PhoneNumberUtil {
   /**
    * Helper function to check the country calling code is valid.
    */
-  private boolean hasValidCountryCallingCode(int countryCallingCode) {
+  public boolean hasValidCountryCallingCode(int countryCallingCode) {
     return countryCallingCodeToRegionCodeMap.containsKey(countryCallingCode);
   }
 


### PR DESCRIPTION
we have telephone number's usage by format with country code-national numbers: The country code can be some numbers called internal country code we customized which not belong to standard ISO country codes. So we need one method to judge if the country code belong to ISO country codes and then to do some special logic.

So I found this method with private. so I advice to change to public for this method. Maybe it will be popular method to judge is country code is valid.

WDTY?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1623)
<!-- Reviewable:end -->
