### PR TITLE
FAQ addition about country calling codes 388 and 991

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -228,6 +228,14 @@ We only support a country if:
     have a region code assigned to it, so we could not support it until it was
     assigned XK by [CLDR](http://cldr.unicode.org/).
 
+We support non-geographical entities that have been assigned country calling
+codes by the ITU where a numbering plan is available, e.g. "800" (International
+Freephone Service) and 870 (Inmarsat SNAC). However we do not support country
+calling codes that are only "reserved", or that no data is available for (namely
+388 - listed as "Group of countries, shared code" and 991 - listed as "Trial of
+a proposed new international telecommunication public correspondence service,
+shared code".)
+
 ## Misc
 
 ### <a name="reduced_metadata"></a>What is the metadatalite.js/METADATA_LITE option?


### PR DESCRIPTION
Replacement for PR #1635 - explicitly addressing the reasons behind the missing assigned country calling codes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1681)
<!-- Reviewable:end -->
