### PR TITLE
Removing revision number in JS README, it's obsolete now we use github.

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -48,7 +48,7 @@ To use and compile the library in your own project, use the `javascript/i18n/pho
 
 How to update:
 ==============
-The JavaScript library is ported from the Java implementation (revision 536).
+The JavaScript library is ported from the Java implementation.
 When the Java project gets updated follow these steps to update the JavaScript
 project:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/libphonenumber/1727)
<!-- Reviewable:end -->
