### PR TITLE
Update GB (+44) carrier data from Ofcom

### DIFF
--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -13,9 +13,108 @@
 # limitations under the License.
 
 # Carrier details updated from http://www.ofcom.org.uk/static/numbering/S7.xls
-# Carrier names have been updated to friendlier trading/brand names
-# The mapping of company names can be found in the project below.
-# Generated on 2017-07-14 via https://github.com/giggsey/GBCarrierGenerator
+# Generated on 2017-07-14.
+
+# Carrier names have been updated to friendlier trading/brand names.
+# The mapping of company names can be found in the project below:
+#  - (aq) Limited trading as aql: aql
+#  - 08Direct Limited: 08Direct
+#  - 09 Mobile Ltd: 09 Mobile
+#  - 24 Seven Communications Ltd: 24 Seven
+#  - AMSUK LTD: AMSUK
+#  - Ace Call Limited: Ace Call
+#  - Airwave Solutions Ltd: Airwave
+#  - Alliance Technologies LLC: Alliance
+#  - Andrews & Arnold Ltd: Andrews & Arnold
+#  - Anywhere Sim Limited: Anywhere Sim
+#  - BT OnePhone Limited: BT OnePhone
+#  - Bellingham Telecommunications Limited: Bellingham
+#  - CFL Communications Limited: CFL
+#  - Cheers International Sales Limited: Cheers
+#  - Citrus Telecommunications Ltd: Citrus
+#  - Cloud9 Communications Limited: Cloud9
+#  - Cloud9 Mobile Communications Ltd: Cloud9
+#  - Compatel Ltd: Compatel
+#  - Confabulate Limited: Confabulate
+#  - Core Communication Services Ltd: Core Communication
+#  - Core Telecom Limited: Core Telecom
+#  - Dynamic Mobile Billing Limited: Oxygen8
+#  - EE Limited ( TM): EE
+#  - EE Limited (Orange): Orange
+#  - Esendex Limited: Esendex
+#  - FleXtel Limited: FleXtel
+#  - Fogg Mobile AB: Fogg
+#  - Gamma Telecom Holdings Ltd: Gamma Telecom
+#  - Global Reach Networks Limited: GlobalReach
+#  - Globecom International Limited.: Globecom
+#  - Guernsey Airtel Limited: Airtel
+#  - HAY SYSTEMS LIMITED: HSL
+#  - Hanhaa Limited: Hanhaa
+#  - Hutchison 3G UK Ltd: Three
+#  - IPV6 Limited: IPV6
+#  - IV Response Limited: IV Response
+#  - Icron Network: Icron
+#  - Icron Network Limited: Icron Network
+#  - JT (Guernsey) Limited: JT
+#  - JT (Jersey) Limited: Jersey Telecom
+#  - Jersey Airtel  Limited: Airtel
+#  - Lanonyx Telecom Limited: Lanonyx
+#  - LegendTel LLC: LegendTel
+#  - Limitless Mobile Ltd: Limitless
+#  - Lleida.net Serveis Telematics Limited: Lleida.net
+#  - Lycamobile UK Limited: Lycamobile
+#  - M P Tanner Limited t/a FIO Telecom: FIO Telecom
+#  - MOBIWEB TELECOM LIMITED: Mobiweb
+#  - Magrathea Telecommunications Limited: Magrathea
+#  - Manx Telecom Trading Limited: Manx Telecom
+#  - Marathon Telecom Limited: Marathon Telecom
+#  - Mars Communications Limited: Mars
+#  - Media Telecom Ltd: Media
+#  - Nationwide Telephone Assistance Ltd: Nationwide Telephone
+#  - Nodemax Limited: Nodemax
+#  - PageOne Communications Ltd: PageOne
+#  - Plus Telecom Limited: Plus
+#  - Premium O Limited: Premium O
+#  - Premium Routing GmbH: Premium Routing
+#  - QX Telecom Ltd: QX Telecom
+#  - Relax Telecom Limited: Relax
+#  - Resilient Plc: Resilient
+#  - Simwood eSMS Limited: Simwood
+#  - Sky UK Limited: Sky
+#  - Sound Advertising Ltd: Mediatel
+#  - Spacetel UK Ltd: Spacetel
+#  - Stour Marine Limited: Stour Marine
+#  - Sure (Guernsey) Limited: Sure
+#  - Sure (Isle of Man) Limited: Sure
+#  - Sure (Jersey) Limited: Sure
+#  - Swiftnet Ltd: Swiftnet
+#  - Synectiv Ltd: Synectiv
+#  - Syntec Limited: Syntec
+#  - TGL Services (UK) Ltd: TGL
+#  - TalkTalk Communications Limited: TalkTalk
+#  - TeleWare PLC: TeleWare
+#  - Telecom 10 Ltd: Telecom 10
+#  - Telecom North America Mobile Inc: Telna
+#  - Telecom2 Ltd: Telecom2
+#  - Telecoms Cloud Networks Limited: Telecoms Cloud
+#  - Teleena UK Limited: Teleena
+#  - Telefonica UK Limited: O2
+#  - Telesign Mobile Limited: Telesign
+#  - Telsis Systems Ltd: Telsis
+#  - Test2date B.V: Test2date
+#  - Tismi BV: Tismi
+#  - Truphone Ltd: Truphone
+#  - UK Broadband Limited: UK Broadband
+#  - Vectone Mobile Limited: Vectone Mobile
+#  - Virgin Mobile Telecoms Limited: Virgin Mobile
+#  - Vodafone Uk Ltd: Vodafone
+#  - Voicetec Systems Ltd: Voicetec
+#  - Voxbone SA: Voxbone
+#  - Wavecrest (UK) Ltd: Wavecrest
+#  - Yim Siam Telecom: Yim Siam
+#  - Ziron (UK) Ltd: Ziron
+#  - aql Wholesale Limited: aql
+
 
 447106|O2
 447107|O2

--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -26,6 +26,13 @@
 447340|Vodafone
 447341|Vodafone
 447342|Vodafone
+447365|Hutchison
+447366|Hutchison
+447367|Hutchison
+4473680|Teleena
+4473682|Sky
+4473683|Sky
+4473699|Anywhere Sim
 447375|EE
 447376|EE
 447377|EE
@@ -36,6 +43,7 @@
 4473800|AMSUK
 447381|O2
 447382|O2
+447383|Hutchison
 447384|Vodafone
 447385|Vodafone
 447386|Vodafone
@@ -47,6 +55,7 @@
 4473893|TalkTalk
 4473894|TalkTalk
 4473895|TalkTalk
+4473896|Hanhaa
 4473897|Vodafone
 4473898|Vodafone
 4473900|Home Office
@@ -56,7 +65,15 @@
 447394|O2
 447395|O2
 447396|EE
-447397|Hutchison
+4473970|Hutchison
+4473971|Hutchison
+4473972|Hutchison
+4473973|Hutchison
+4473975|Hutchison
+4473976|Hutchison
+4473977|Hutchison
+4473978|Hutchison
+4473979|Hutchison
 447398|EE
 447399|EE
 447400|Hutchison
@@ -68,7 +85,6 @@
 4474060|Cheers
 4474061|Cheers
 4474062|Cheers
-4474064|Titanium
 4474065|Telecom2
 4474066|24 Seven
 4474067|TGL
@@ -93,7 +109,6 @@
 4474173|Lycamobile
 4474174|Lycamobile
 4474175|Lycamobile
-4474176|Proton
 4474178|Truphone
 4474179|Core Telecom
 4474180|Hutchison
@@ -106,16 +121,13 @@
 4474187|Teleena
 4474189|Teleena
 447419|Orange
+44742|Hutchison
 447420|Orange
 447421|Orange
 447422|Orange
 447423|Vodafone
 447424|Lycamobile
 447425|Vodafone
-447426|Hutchison
-447427|Hutchison
-447428|Hutchison
-447429|Hutchison
 447430|O2
 447431|O2
 447432|EE
@@ -149,37 +161,24 @@
 447447|Hutchison
 447448|Lycamobile
 447449|Hutchison
-447450|Hutchison
-4474510|Mundio
-4474511|Mundio
+44745|Hutchison
+447451|Vectone Mobile
 4474512|Tismi
-4474513|Mundio
-4474514|Mundio
 4474515|Premium O
 4474516|UK Broadband
 4474517|UK Broadband
-4474518|Mundio
-4474519|Mundio
 447452|Manx Telecom
 4474527|Hutchison
 4474528|Hutchison
 4474529|Hutchison
-447453|Hutchison
-447454|Hutchison
-447455|Hutchison
-447456|Hutchison
-4474570|Mundio
-4474571|Mundio
+447457|Vectone Mobile
 4474572|Marathon Telecom
-4474573|Mundio
 4474574|Voicetec
-4474575|Mundio
 4474576|Sure
 4474577|Spacetel
 4474578|CardBoardFish
 4474579|CardBoardFish
-4474580|Gamma Telecom
-4474581|Gamma Telecom
+447458|Gamma Telecom
 4474582|Premium Routing
 4474583|Virgin Mobile
 4474584|Airwave
@@ -189,21 +188,13 @@
 4474588|Limitless
 4474589|Hutchison
 447459|Lycamobile
-447460|Hutchison
+44746|Hutchison
 447461|O2
-447462|Hutchison
-447463|Hutchison
 447464|Vodafone
-4474650|Mundio
-4474651|Mundio
-4474652|Hutchison
+4474650|Vectone Mobile
+4474651|Vectone Mobile
 4474653|Compatel
-4474654|Hutchison
-4474655|Netfuse
-4474656|Hutchison
-4474657|Hutchison
-4474658|Hutchison
-4474659|Hutchison
+4474655|GlobalReach
 447466|Lycamobile
 447467|Vodafone
 447468|Vodafone
@@ -211,34 +202,23 @@
 44747|Hutchison
 447470|Vodafone
 447471|Vodafone
+44748|EE
 447480|Hutchison
 447481|Hutchison
 447482|Hutchison
-447483|EE
-447484|EE
-447485|EE
-447486|EE
-447487|EE
+447488|Hutchison
 4474880|Fogg
 4474881|CESG
 4474882|Sky
 4474883|Sky
-4474884|Hutchison
-4474885|Hutchison
 4474886|Lanonyx
-4474887|Hutchison
 4474888|Ziron
-4474889|Hutchison
 447489|O2
+44749|EE
 447490|Hutchison
 447491|Hutchison
 447492|Hutchison
 447493|Vodafone
-447494|EE
-447495|EE
-447496|EE
-447497|EE
-447498|EE
 447499|O2
 447500|Vodafone
 447501|Vodafone
@@ -260,13 +240,11 @@
 44751|O2
 4475200|Simwood
 4475201|BT OnePhone
-4475202|Mundio
+4475202|Vectone Mobile
 4475204|Core Communication
 4475205|Esendex
 4475206|Tismi
 4475207|aql
-4475208|Fonix
-4475209|Invomo
 447521|O2
 447522|O2
 447523|O2
@@ -277,11 +255,7 @@
 447529|Orange
 447530|Orange
 447531|Orange
-4475320|Orange
-4475321|Orange
-4475322|Orange
-4475323|Orange
-4475324|Orange
+447532|Orange
 4475325|SMSRelay AG
 4475326|Hutchison
 4475327|Hutchison
@@ -347,12 +321,11 @@
 4475891|Oxygen8
 4475892|Oxygen8
 4475893|Oxygen8
-4475894|Mundio
-4475895|Mundio
-4475896|Mundio
-4475897|Mundio
+4475894|Vectone Mobile
+4475895|Vectone Mobile
+4475896|Vectone Mobile
+4475897|Vectone Mobile
 4475898|Test2date
-4475899|Moonshado
 44759|O2
 4476000|Mediatel
 4476002|PageOne
@@ -361,13 +334,19 @@
 4476020|O2
 4476022|Relax
 447623|PageOne
-447624|Manx Telecom
+4476240|Manx Telecom
+4476241|Manx Telecom
 4476242|Sure
+4476243|Manx Telecom
+4476244|Manx Telecom
+4476246|Manx Telecom
+4476248|Manx Telecom
+4476249|Manx Telecom
 447625|O2
 447626|O2
 4476400|Core Telecom
 4476401|Telecom2
-4476402|M P Tanner
+4476402|FIO Telecom
 4476403|PageOne
 4476404|PageOne
 4476406|PageOne
@@ -376,8 +355,6 @@
 4476433|Yim Siam
 4476440|O2
 4476441|O2
-4476444|Titanium
-4476445|Proton
 4476446|Media
 4476542|PageOne
 4476543|PageOne
@@ -391,25 +368,20 @@
 4476596|Vodafone
 4476598|Vodafone
 4476599|PageOne
+447660|PageOne
 4476600|Plus
-4476601|PageOne
-4476602|PageOne
-4476603|PageOne
-4476604|PageOne
-4476605|PageOne
 4476606|24 Seven
 4476607|Premium O
 4476608|Premium O
 4476609|Premium O
 447661|PageOne
 4476620|Premium O
-4476630|Switch
 4476633|Syntec
 4476636|Relax
 4476637|Vodafone
 447666|Vodafone
 4476660|24 Seven
-4476669|M P Tanner
+4476669|FIO Telecom
 4476690|O2
 4476691|O2
 4476692|O2
@@ -442,16 +414,13 @@
 447709|O2
 44771|O2
 447717|Vodafone
-447720|O2
+44772|O2
 447721|Vodafone
 447722|EE
 447723|Hutchison
-447724|O2
-447725|O2
 447726|EE
 447727|Hutchison
 447728|Hutchison
-447729|O2
 44773|O2
 447733|Vodafone
 447735|Hutchison
@@ -492,26 +461,16 @@
 447762|O2
 447763|O2
 447764|O2
-447770|Vodafone
-447771|Vodafone
+44777|Vodafone
 447772|Orange
 447773|Orange
-447774|Vodafone
-447775|Vodafone
-447776|Vodafone
-447777|BT
-447778|Vodafone
+447777|EE
 447779|Orange
-447780|Vodafone
+44778|Vodafone
 447781|Sure
 447782|Hutchison
 447783|O2
 447784|O2
-447785|Vodafone
-447786|Vodafone
-447787|Vodafone
-447788|Vodafone
-447789|Vodafone
 447790|Orange
 447791|Orange
 447792|Orange
@@ -524,16 +483,12 @@
 4477979|Jersey Telecom
 447798|Vodafone
 447799|Vodafone
+44780|O2
 447800|Orange
-447801|O2
-447802|O2
-447803|O2
 447804|EE
 447805|Orange
 447806|EE
 447807|Orange
-447808|O2
-447809|O2
 44781|Orange
 447810|Vodafone
 447818|Vodafone
@@ -544,7 +499,7 @@
 4478221|Swiftnet
 4478222|TalkTalk
 4478224|aql
-4478225|Icron
+4478225|Icron Network
 4478226|aql
 4478227|Cheers
 4478228|Vodafone
@@ -575,22 +530,25 @@
 447846|Hutchison
 447847|EE
 447848|Hutchison
-447850|O2
-447851|O2
+44785|O2
 447852|EE
 447853|Hutchison
 447854|Orange
 447855|Orange
-447856|O2
-447857|O2
-447858|O2
 447859|Hutchison
 447860|O2
 447861|Hutchison
 447862|Hutchison
 447863|Hutchison
-447864|O2
-4478644|Switch
+4478640|O2
+4478641|O2
+4478642|O2
+4478643|O2
+4478645|O2
+4478646|O2
+4478647|O2
+4478648|O2
+4478649|O2
 447865|Hutchison
 447866|Orange
 447867|Vodafone
@@ -600,7 +558,7 @@
 447871|O2
 447872|O2
 4478722|Cloud9
-4478727|Sky
+4478727|Telecom 10
 447873|O2
 4478730|Telesign
 4478740|O2
@@ -617,21 +575,17 @@
 447877|Hutchison
 447878|Hutchison
 447879|Vodafone
-447880|Vodafone
-447881|Vodafone
+44788|Vodafone
 447882|Hutchison
 447883|Hutchison
-447884|Vodafone
 447885|O2
 447886|Hutchison
-447887|Vodafone
 447888|Hutchison
 447889|O2
 447890|Orange
 447891|Orange
 4478920|HSL
-4478921|Mundio
-4478922|Edge Telecom
+4478921|Vectone Mobile
 4478923|O2
 4478924|O2
 4478925|FleXtel
@@ -639,14 +593,10 @@
 4478927|O2
 4478928|O2
 4478929|O2
+447893|O2
 4478930|Magrathea
 4478931|24 Seven
-4478932|O2
 4478933|Yim Siam
-4478934|O2
-4478935|O2
-4478936|O2
-4478937|O2
 4478938|aql
 4478939|Citrus
 447894|O2
@@ -655,15 +605,11 @@
 447897|Hutchison
 447898|Hutchison
 447899|Vodafone
+44790|EE
 447900|Vodafone
 447901|Vodafone
 447902|O2
-447903|EE
-447904|EE
-447905|EE
-447906|EE
 447907|O2
-447908|EE
 447909|Vodafone
 447910|EE
 4479110|Marathon Telecom
@@ -679,26 +625,16 @@
 447917|Vodafone
 447918|Vodafone
 447919|Vodafone
+44792|O2
 447920|Vodafone
-447921|O2
-447922|O2
-447923|O2
 447924|Manx Telecom
 4479245|Cloud9
-447925|O2
-447926|O2
-447927|O2
-447928|O2
 447929|Orange
+44793|O2
 447930|EE
 447931|EE
 447932|EE
-447933|O2
-447934|O2
-447935|O2
-447936|O2
 447937|Jersey Telecom
-447938|O2
 447939|EE
 44794|EE
 44795|EE
@@ -720,11 +656,11 @@
 4479782|Cloud9
 4479783|Cloud9
 4479784|Cheers
-4479785|Icron
+4479785|Icron Network
 4479786|Oxygen8
 4479787|TeleWare
 4479788|Truphone
-4479789|ivr
+4479789|IV Response
 447979|Vodafone
 44798|EE
 447980|Orange

--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Carrier details updated from http://www.ofcom.org.uk/static/numbering/S7.xls
-# Generated on 2017-07-14.
+# Generated on 2017-07-14 using https://github.com/giggsey/GBCarrierGenerator
 
 # Carrier names have been updated to friendlier trading/brand names.
 # The mapping of company names can be found in the project below:
@@ -56,7 +56,7 @@
 #  - Icron Network: Icron
 #  - Icron Network Limited: Icron Network
 #  - JT (Guernsey) Limited: JT
-#  - JT (Jersey) Limited: Jersey Telecom
+#  - JT (Jersey) Limited: JT
 #  - Jersey Airtel  Limited: Airtel
 #  - Lanonyx Telecom Limited: Lanonyx
 #  - LegendTel LLC: LegendTel
@@ -114,7 +114,6 @@
 #  - Yim Siam Telecom: Yim Siam
 #  - Ziron (UK) Ltd: Ziron
 #  - aql Wholesale Limited: aql
-
 
 447106|O2
 447107|O2
@@ -331,14 +330,14 @@
 447506|EE
 447507|EE
 447508|EE
-4475090|Jersey Telecom
-4475091|Jersey Telecom
-4475092|Jersey Telecom
-4475093|Jersey Telecom
-4475094|Jersey Telecom
-4475095|Jersey Telecom
-4475096|Jersey Telecom
-4475097|Jersey Telecom
+4475090|JT
+4475091|JT
+4475092|JT
+4475093|JT
+4475094|JT
+4475095|JT
+4475096|JT
+4475097|JT
 44751|O2
 4475200|Simwood
 4475201|BT OnePhone
@@ -580,9 +579,9 @@
 447794|Orange
 447795|Vodafone
 447796|Vodafone
-4477977|Jersey Telecom
-4477978|Jersey Telecom
-4477979|Jersey Telecom
+4477977|JT
+4477978|JT
+4477979|JT
 447798|Vodafone
 447799|Vodafone
 44780|O2
@@ -736,7 +735,7 @@
 447930|EE
 447931|EE
 447932|EE
-447937|Jersey Telecom
+447937|JT
 447939|EE
 44794|EE
 44795|EE

--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -16,7 +16,7 @@
 # Generated on 2017-07-14 using https://github.com/giggsey/GBCarrierGenerator
 
 # Carrier names have been updated to friendlier trading/brand names.
-# The mapping of company names can be found in the project below:
+# The mapping of company names can be found below:
 #  - (aq) Limited trading as aql: aql
 #  - 08Direct Limited: 08Direct
 #  - 09 Mobile Ltd: 09 Mobile

--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 # Carrier details updated from http://www.ofcom.org.uk/static/numbering/S7.xls
+# Carrier names have been updated to friendlier trading/brand names
+# The mapping of company names can be found in the project below.
+# Generated on 2017-07-14 via https://github.com/giggsey/GBCarrierGenerator
 
 447106|O2
 447107|O2
@@ -26,9 +29,9 @@
 447340|Vodafone
 447341|Vodafone
 447342|Vodafone
-447365|Hutchison
-447366|Hutchison
-447367|Hutchison
+447365|Three
+447366|Three
+447367|Three
 4473680|Teleena
 4473682|Sky
 4473683|Sky
@@ -36,21 +39,21 @@
 447375|EE
 447376|EE
 447377|EE
-447378|Hutchison
+447378|Three
 4473780|Limitless
 447379|Vodafone
-447380|Hutchison
+447380|Three
 4473800|AMSUK
 447381|O2
 447382|O2
-447383|Hutchison
+447383|Three
 447384|Vodafone
 447385|Vodafone
 447386|Vodafone
 447387|Vodafone
 447388|Vodafone
-4473890|Hutchison
-4473891|Hutchison
+4473890|Three
+4473891|Three
 4473892|TalkTalk
 4473893|TalkTalk
 4473894|TalkTalk
@@ -65,21 +68,21 @@
 447394|O2
 447395|O2
 447396|EE
-4473970|Hutchison
-4473971|Hutchison
-4473972|Hutchison
-4473973|Hutchison
-4473975|Hutchison
-4473976|Hutchison
-4473977|Hutchison
-4473978|Hutchison
-4473979|Hutchison
+4473970|Three
+4473971|Three
+4473972|Three
+4473973|Three
+4473975|Three
+4473976|Three
+4473977|Three
+4473978|Three
+4473979|Three
 447398|EE
 447399|EE
-447400|Hutchison
-447401|Hutchison
-447402|Hutchison
-447403|Hutchison
+447400|Three
+447401|Three
+447402|Three
+447403|Three
 447404|Lycamobile
 447405|Lycamobile
 4474060|Cheers
@@ -98,10 +101,10 @@
 4474089|Truphone
 447409|Orange
 447410|Orange
-447411|Hutchison
-447412|Hutchison
-447413|Hutchison
-447414|Hutchison
+447411|Three
+447412|Three
+447413|Three
+447414|Three
 447415|EE
 447416|Orange
 4474171|CardBoardFish
@@ -111,7 +114,7 @@
 4474175|Lycamobile
 4474178|Truphone
 4474179|Core Telecom
-4474180|Hutchison
+4474180|Three
 4474181|Bellingham
 4474182|TGL
 4474183|Tismi
@@ -121,7 +124,7 @@
 4474187|Teleena
 4474189|Teleena
 447419|Orange
-44742|Hutchison
+44742|Three
 447420|Orange
 447421|Orange
 447422|Orange
@@ -156,21 +159,21 @@
 447442|Vodafone
 447443|Vodafone
 447444|Vodafone
-447445|Hutchison
-447446|Hutchison
-447447|Hutchison
+447445|Three
+447446|Three
+447447|Three
 447448|Lycamobile
-447449|Hutchison
-44745|Hutchison
+447449|Three
+44745|Three
 447451|Vectone Mobile
 4474512|Tismi
 4474515|Premium O
 4474516|UK Broadband
 4474517|UK Broadband
 447452|Manx Telecom
-4474527|Hutchison
-4474528|Hutchison
-4474529|Hutchison
+4474527|Three
+4474528|Three
+4474529|Three
 447457|Vectone Mobile
 4474572|Marathon Telecom
 4474574|Voicetec
@@ -183,12 +186,12 @@
 4474583|Virgin Mobile
 4474584|Airwave
 4474585|Marathon Telecom
-4474586|Hutchison
+4474586|Three
 4474587|Limitless
 4474588|Limitless
-4474589|Hutchison
+4474589|Three
 447459|Lycamobile
-44746|Hutchison
+44746|Three
 447461|O2
 447464|Vodafone
 4474650|Vectone Mobile
@@ -199,14 +202,14 @@
 447467|Vodafone
 447468|Vodafone
 447469|Vodafone
-44747|Hutchison
+44747|Three
 447470|Vodafone
 447471|Vodafone
 44748|EE
-447480|Hutchison
-447481|Hutchison
-447482|Hutchison
-447488|Hutchison
+447480|Three
+447481|Three
+447482|Three
+447488|Three
 4474880|Fogg
 4474881|CESG
 4474882|Sky
@@ -215,9 +218,9 @@
 4474888|Ziron
 447489|O2
 44749|EE
-447490|Hutchison
-447491|Hutchison
-447492|Hutchison
+447490|Three
+447491|Three
+447492|Three
 447493|Vodafone
 447499|O2
 447500|Vodafone
@@ -257,11 +260,11 @@
 447531|Orange
 447532|Orange
 4475325|SMSRelay AG
-4475326|Hutchison
-4475327|Hutchison
-4475328|Hutchison
+4475326|Three
+4475327|Three
+4475328|Three
 4475329|Mobiweb
-447533|Hutchison
+447533|Three
 447534|EE
 447535|EE
 447536|Orange
@@ -271,8 +274,8 @@
 4475374|Vodafone
 4475376|Mediatel
 4475377|CFL
-4475378|Hutchison
-4475379|Hutchison
+4475378|Three
+4475379|Three
 447538|EE
 447539|EE
 44754|O2
@@ -303,10 +306,10 @@
 447572|EE
 447573|EE
 447574|EE
-447575|Hutchison
-447576|Hutchison
-447577|Hutchison
-447578|Hutchison
+447575|Three
+447576|Three
+447577|Three
+447578|Three
 447579|Orange
 447580|Orange
 447581|Orange
@@ -316,7 +319,7 @@
 447585|Vodafone
 447586|Vodafone
 447587|Vodafone
-447588|Hutchison
+447588|Three
 4475890|Yim Siam
 4475891|Oxygen8
 4475892|Oxygen8
@@ -417,14 +420,14 @@
 44772|O2
 447721|Vodafone
 447722|EE
-447723|Hutchison
+447723|Three
 447726|EE
-447727|Hutchison
-447728|Hutchison
+447727|Three
+447728|Three
 44773|O2
 447733|Vodafone
-447735|Hutchison
-447737|Hutchison
+447735|Three
+447737|Three
 447740|O2
 447741|Vodafone
 447742|O2
@@ -468,7 +471,7 @@
 447779|Orange
 44778|Vodafone
 447781|Sure
-447782|Hutchison
+447782|Three
 447783|O2
 447784|O2
 447790|Orange
@@ -509,37 +512,37 @@
 447825|Vodafone
 447826|Vodafone
 447827|Vodafone
-447828|Hutchison
+447828|Three
 4478297|Airtel
 4478298|Airtel
 4478299|Airtel
-447830|Hutchison
+447830|Three
 447831|Vodafone
-447832|Hutchison
+447832|Three
 447833|Vodafone
 447834|O2
 447835|O2
 447836|Vodafone
 447837|Orange
-447838|Hutchison
+447838|Three
 4478391|Airtel
 4478392|Airtel
 4478397|Airtel
 4478398|Sure
 44784|O2
-447846|Hutchison
+447846|Three
 447847|EE
-447848|Hutchison
+447848|Three
 44785|O2
 447852|EE
-447853|Hutchison
+447853|Three
 447854|Orange
 447855|Orange
-447859|Hutchison
+447859|Three
 447860|O2
-447861|Hutchison
-447862|Hutchison
-447863|Hutchison
+447861|Three
+447862|Three
+447863|Three
 4478640|O2
 4478641|O2
 4478642|O2
@@ -549,11 +552,11 @@
 4478647|O2
 4478648|O2
 4478649|O2
-447865|Hutchison
+447865|Three
 447866|Orange
 447867|Vodafone
-447868|Hutchison
-447869|Hutchison
+447868|Three
+447869|Three
 447870|Orange
 447871|O2
 447872|O2
@@ -572,15 +575,15 @@
 4478749|O2
 447875|Orange
 447876|Vodafone
-447877|Hutchison
-447878|Hutchison
+447877|Three
+447878|Three
 447879|Vodafone
 44788|Vodafone
-447882|Hutchison
-447883|Hutchison
+447882|Three
+447883|Three
 447885|O2
-447886|Hutchison
-447888|Hutchison
+447886|Three
+447888|Three
 447889|O2
 447890|Orange
 447891|Orange
@@ -602,8 +605,8 @@
 447894|O2
 447895|O2
 447896|Orange
-447897|Hutchison
-447898|Hutchison
+447897|Three
+447898|Three
 447899|Vodafone
 44790|EE
 447900|Vodafone
@@ -620,8 +623,8 @@
 447912|O2
 447913|EE
 447914|EE
-447915|Hutchison
-447916|Hutchison
+447915|Three
+447916|Three
 447917|Vodafone
 447918|Vodafone
 447919|Vodafone
@@ -664,7 +667,7 @@
 447979|Vodafone
 44798|EE
 447980|Orange
-447988|Hutchison
+447988|Three
 447989|Orange
 447990|Vodafone
 447999|O2


### PR DESCRIPTION
Uses the most recent carrier data from Ofcom, with carrier names being changed to friendlier versions (brand/trading names).

Data has also been compressed to reduce duplicate prefixes, although the script has compressed it further than it used to be.

Generated using https://github.com/giggsey/GBCarrierGenerator (so can be run again).

A few questions about the company names:
 - [x] The current data converts Hutchison 3G UK Ltd to Hutchison. Their commonly used brand name is 3/Three.
 - [x] Vectone Mobile Limited is called Mundio in your data (from Wikipedia: Vectone Mobile is operated by Mundio Mobile Ltd). However, their [website](https://www.vectonemobile.co.uk/) just calls themselves Vectone Mobile
 - [x] M P Tanner Limited t/a FIO Telecom has been translated to their trading name FIO Telecom