### PR TITLE
Improve parsing logic to be smarter about national-prefix detection & stripping.

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -1786,11 +1786,8 @@ void PhoneNumberUtil::GetRegionCodeForNumber(const PhoneNumber& number,
   std::list<string> region_codes;
   GetRegionCodesForCountryCallingCode(country_calling_code, &region_codes);
   if (region_codes.size() == 0) {
-    string number_string;
-    GetNationalSignificantNumber(number, &number_string);
     VLOG(1) << "Missing/invalid country calling code ("
-            << country_calling_code
-            << ") for number " << number_string;
+            << country_calling_code << ")";
     *region_code = RegionCode::GetUnknown();
     return;
   }
@@ -2256,9 +2253,6 @@ void PhoneNumberUtil::ExtractPossibleNumber(const string& number,
     return;
   }
 
-  VLOG(3) << "After stripping starting and trailing characters, left with: "
-          << *extracted_number;
-
   // Now remove any extra numbers at the end.
   reg_exps_->capture_up_to_second_number_start_pattern_->
       PartialMatch(*extracted_number, extracted_number);
@@ -2649,7 +2643,6 @@ void PhoneNumberUtil::Normalize(string* number) const {
 // method ExtractPossibleNumber.
 bool PhoneNumberUtil::IsViablePhoneNumber(const string& number) const {
   if (number.length() < kMinLengthForNsn) {
-    VLOG(2) << "Number too short to be viable:" << number;
     return false;
   }
   return reg_exps_->valid_phone_number_pattern_->FullMatch(number);
@@ -2817,11 +2810,6 @@ bool PhoneNumberUtil::MaybeStripExtension(string* number, string* extension)
                             &possible_extension_three)) {
     // Replace the extensions in the original string here.
     reg_exps_->extn_pattern_->Replace(&number_copy, "");
-    VLOG(4) << "Found an extension. Possible extension one: "
-            << possible_extension_one
-            << ". Possible extension two: " << possible_extension_two
-            << ". Possible extension three: " << possible_extension_three
-            << ". Remaining number: " << number_copy;
     // If we find a potential extension, and the number preceding this is a
     // viable number, we assume it is an extension.
     if ((!possible_extension_one.empty() || !possible_extension_two.empty() ||
@@ -2932,8 +2920,6 @@ PhoneNumberUtil::ErrorType PhoneNumberUtil::MaybeExtractCountryCode(
       MaybeStripNationalPrefixAndCarrierCode(*default_region_metadata,
                                              &potential_national_number,
                                              NULL);
-      VLOG(4) << "Number without country calling code prefix: "
-              << potential_national_number;
       // If the number was not valid before but is valid now, or if it was too
       // long before, we consider the number with the country code stripped to
       // be a better result and keep that instead.

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -316,9 +316,6 @@ void GetSupportedTypesForMetadata(
 
 // Helper method to check a number against possible lengths for this number
 // type, and determine whether it matches, or is too short or too long.
-// Currently, if a number pattern suggests that numbers of length 7 and 10 are
-// possible, and a number in between these possible lengths is entered, such as
-// of length 8, this will return TOO_LONG.
 PhoneNumberUtil::ValidationResult TestNumberLength(
     const string& number, const PhoneMetadata& metadata,
     PhoneNumberUtil::PhoneNumberType type) {
@@ -397,9 +394,7 @@ PhoneNumberUtil::ValidationResult TestNumberLength(
 
 // Helper method to check a number against possible lengths for this region,
 // based on the metadata being passed in, and determine whether it matches, or
-// is too short or too long. Currently, if a number pattern suggests that
-// numbers of length 7 and 10 are possible, and a number in between these
-// possible lengths is entered, such as of length 8, this will return TOO_LONG.
+// is too short or too long.
 PhoneNumberUtil::ValidationResult TestNumberLength(
     const string& number, const PhoneMetadata& metadata) {
   return TestNumberLength(number, metadata, PhoneNumberUtil::UNKNOWN);

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -2184,8 +2184,11 @@ PhoneNumberUtil::ErrorType PhoneNumberUtil::ParseHelper(
     // and carrier code be long enough to be a possible length for the region.
     // Otherwise, we don't do the stripping, since the original number could be
     // a valid short number.
-    if (TestNumberLength(potential_national_number, *country_metadata) !=
-        TOO_SHORT) {
+    ValidationResult validation_result =
+        TestNumberLength(potential_national_number, *country_metadata);
+    if (validation_result != TOO_SHORT &&
+        validation_result != IS_POSSIBLE_LOCAL_ONLY &&
+        validation_result != INVALID_LENGTH) {
       normalized_national_number.assign(potential_national_number);
       if (keep_raw_input && !carrier_code.empty()) {
         temp_number.set_preferred_domestic_carrier_code(carrier_code);

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -3663,8 +3663,8 @@ TEST_F(PhoneNumberUtilTest, ParseNationalNumber) {
             phone_util_.Parse("12", RegionCode::NZ(), &test_number));
   EXPECT_EQ(short_number, test_number);
 
-  // Test for b/64235606. short-code with leading zero for a country which has 0
-  // as national prefix. Ensure it's not interpreted as national prefix if the
+  // Test for short-code with leading zero for a country which has 0 as
+  // national prefix. Ensure it's not interpreted as national prefix if the
   // remaining number length is local-only in terms of length. Example: In GB,
   // length 6-7 are only possible local-only.
   short_number.set_country_code(44);

--- a/cpp/test/phonenumbers/phonenumberutil_test.cc
+++ b/cpp/test/phonenumbers/phonenumberutil_test.cc
@@ -3662,6 +3662,17 @@ TEST_F(PhoneNumberUtilTest, ParseNationalNumber) {
   EXPECT_EQ(PhoneNumberUtil::NO_PARSING_ERROR,
             phone_util_.Parse("12", RegionCode::NZ(), &test_number));
   EXPECT_EQ(short_number, test_number);
+
+  // Test for b/64235606. short-code with leading zero for a country which has 0
+  // as national prefix. Ensure it's not interpreted as national prefix if the
+  // remaining number length is local-only in terms of length. Example: In GB,
+  // length 6-7 are only possible local-only.
+  short_number.set_country_code(44);
+  short_number.set_national_number(123456);
+  short_number.set_italian_leading_zero(true);
+  EXPECT_EQ(PhoneNumberUtil::NO_PARSING_ERROR,
+            phone_util_.Parse("0123456", RegionCode::GB(), &test_number));
+  EXPECT_EQ(short_number, test_number);
 }
 
 TEST_F(PhoneNumberUtilTest, ParseNumberWithAlphaCharacters) {

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -3218,10 +3218,10 @@ public class PhoneNumberUtil {
       // We require that the NSN remaining after stripping the national prefix and carrier code be
       // long enough to be a possible length for the region. Otherwise, we don't do the stripping,
       // since the original number could be a valid short number.
-      ValidationResult validatonResult = testNumberLength(potentialNationalNumber, regionMetadata);
-      if (validatonResult != ValidationResult.TOO_SHORT
-          && validatonResult != ValidationResult.IS_POSSIBLE_LOCAL_ONLY
-          && validatonResult != ValidationResult.INVALID_LENGTH) {
+      ValidationResult validationResult = testNumberLength(potentialNationalNumber, regionMetadata);
+      if (validationResult != ValidationResult.TOO_SHORT
+          && validationResult != ValidationResult.IS_POSSIBLE_LOCAL_ONLY
+          && validationResult != ValidationResult.INVALID_LENGTH) {
         normalizedNationalNumber = potentialNationalNumber;
         if (keepRawInput && carrierCode.length() > 0) {
           phoneNumber.setPreferredDomesticCarrierCode(carrierCode.toString());

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -656,7 +656,6 @@ public class PhoneNumberUtil {
       Matcher trailingCharsMatcher = UNWANTED_END_CHAR_PATTERN.matcher(number);
       if (trailingCharsMatcher.find()) {
         number = number.subSequence(0, trailingCharsMatcher.start());
-        logger.log(Level.FINER, "Stripped trailing characters: " + number);
       }
       // Check for extra numbers at the end.
       Matcher secondNumber = SECOND_NUMBER_START_PATTERN.matcher(number);
@@ -2290,9 +2289,7 @@ public class PhoneNumberUtil {
     int countryCode = number.getCountryCode();
     List<String> regions = countryCallingCodeToRegionCodeMap.get(countryCode);
     if (regions == null) {
-      String numberString = getNationalSignificantNumber(number);
-      logger.log(Level.INFO,
-                 "Missing/invalid country_code (" + countryCode + ") for number " + numberString);
+      logger.log(Level.INFO, "Missing/invalid country_code (" + countryCode + ")");
       return null;
     }
     if (regions.size() == 1) {

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -2478,9 +2478,7 @@ public class PhoneNumberUtil {
 
   /**
    * Helper method to check a number against possible lengths for this region, based on the metadata
-   * being passed in, and determine whether it matches, or is too short or too long. Currently, if a
-   * number pattern suggests that numbers of length 7 and 10 are possible, and a number in between
-   * these possible lengths is entered, such as of length 8, this will return TOO_LONG.
+   * being passed in, and determine whether it matches, or is too short or too long.
    */
   private ValidationResult testNumberLength(CharSequence number, PhoneMetadata metadata) {
     return testNumberLength(number, metadata, PhoneNumberType.UNKNOWN);
@@ -2488,9 +2486,7 @@ public class PhoneNumberUtil {
 
   /**
    * Helper method to check a number against possible lengths for this number type, and determine
-   * whether it matches, or is too short or too long. Currently, if a number pattern suggests that
-   * numbers of length 7 and 10 are possible, and a number in between these possible lengths is
-   * entered, such as of length 8, this will return TOO_LONG.
+   * whether it matches, or is too short or too long.
    */
   private ValidationResult testNumberLength(
       CharSequence number, PhoneMetadata metadata, PhoneNumberType type) {
@@ -3222,7 +3218,10 @@ public class PhoneNumberUtil {
       // We require that the NSN remaining after stripping the national prefix and carrier code be
       // long enough to be a possible length for the region. Otherwise, we don't do the stripping,
       // since the original number could be a valid short number.
-      if (testNumberLength(potentialNationalNumber, regionMetadata) != ValidationResult.TOO_SHORT) {
+      ValidationResult validatonResult = testNumberLength(potentialNationalNumber, regionMetadata);
+      if (validatonResult != ValidationResult.TOO_SHORT
+          && validatonResult != ValidationResult.IS_POSSIBLE_LOCAL_ONLY
+          && validatonResult != ValidationResult.INVALID_LENGTH) {
         normalizedNationalNumber = potentialNationalNumber;
         if (keepRawInput && carrierCode.length() > 0) {
           phoneNumber.setPreferredDomesticCarrierCode(carrierCode.toString());

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -2121,6 +2121,13 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     PhoneNumber shortNumber = new PhoneNumber();
     shortNumber.setCountryCode(64).setNationalNumber(12L);
     assertEquals(shortNumber, phoneUtil.parse("12", RegionCode.NZ));
+
+    // Test for b/64235606. short-code with leading zero for a country which has 0 as national
+    // prefix. Ensure it's not interpreted as national prefix if the remaining number length is
+    // local-only in terms of length. Example: In GB, length 6-7 are only possible local-only.
+    shortNumber.setCountryCode(44).setNationalNumber(123456)
+        .setItalianLeadingZero(true);
+    assertEquals(shortNumber, phoneUtil.parse("0123456", RegionCode.GB));
   }
 
   public void testParseNumberWithAlphaCharacters() throws Exception {

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberUtilTest.java
@@ -2122,9 +2122,9 @@ public class PhoneNumberUtilTest extends TestMetadataTestCase {
     shortNumber.setCountryCode(64).setNationalNumber(12L);
     assertEquals(shortNumber, phoneUtil.parse("12", RegionCode.NZ));
 
-    // Test for b/64235606. short-code with leading zero for a country which has 0 as national
-    // prefix. Ensure it's not interpreted as national prefix if the remaining number length is
-    // local-only in terms of length. Example: In GB, length 6-7 are only possible local-only.
+    // Test for short-code with leading zero for a country which has 0 as national prefix. Ensure
+    // it's not interpreted as national prefix if the remaining number length is local-only in
+    // terms of length. Example: In GB, length 6-7 are only possible local-only.
     shortNumber.setCountryCode(44).setNationalNumber(123456)
         .setItalianLeadingZero(true);
     assertEquals(shortNumber, phoneUtil.parse("0123456", RegionCode.GB));

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4215,9 +4215,14 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.parseHelper_ =
     // carrier code be long enough to be a possible length for the region.
     // Otherwise, we don't do the stripping, since the original number could be
     // a valid short number.
-    if (this.testNumberLength_(potentialNationalNumber.toString(),
-            regionMetadata) !=
-        i18n.phonenumbers.PhoneNumberUtil.ValidationResult.TOO_SHORT) {
+    var validatonResult = this.testNumberLength_(
+        potentialNationalNumber.toString(), regionMetadata);
+    if (validatonResult !=
+        i18n.phonenumbers.PhoneNumberUtil.ValidationResult.TOO_SHORT &&
+	validatonResult !=
+        i18n.phonenumbers.PhoneNumberUtil.ValidationResult.IS_POSSIBLE_LOCAL_ONLY &&
+	validatonResult !=
+        i18n.phonenumbers.PhoneNumberUtil.ValidationResult.INVALID_LENGTH) {
       normalizedNationalNumber = potentialNationalNumber;
       if (keepRawInput && carrierCode.toString().length > 0) {
         phoneNumber.setPreferredDomesticCarrierCode(carrierCode.toString());

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -4215,13 +4215,13 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.parseHelper_ =
     // carrier code be long enough to be a possible length for the region.
     // Otherwise, we don't do the stripping, since the original number could be
     // a valid short number.
-    var validatonResult = this.testNumberLength_(
+    var validationResult = this.testNumberLength_(
         potentialNationalNumber.toString(), regionMetadata);
-    if (validatonResult !=
+    if (validationResult !=
         i18n.phonenumbers.PhoneNumberUtil.ValidationResult.TOO_SHORT &&
-	validatonResult !=
+	validationResult !=
         i18n.phonenumbers.PhoneNumberUtil.ValidationResult.IS_POSSIBLE_LOCAL_ONLY &&
-	validatonResult !=
+	validationResult !=
         i18n.phonenumbers.PhoneNumberUtil.ValidationResult.INVALID_LENGTH) {
       normalizedNationalNumber = potentialNationalNumber;
       if (keepRawInput && carrierCode.toString().length > 0) {

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -3313,9 +3313,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.isPossibleNumberForType =
 /**
  * Helper method to check a number against possible lengths for this region,
  * based on the metadata being passed in, and determine whether it matches, or
- * is too short or too long. Currently, if a number pattern suggests that
- * numbers of length 7 and 10 are possible, and a number in between these
- * possible lengths is entered, such as of length 8, this will return TOO_LONG.
+ * is too short or too long.
  *
  * @param {string} number
  * @param {i18n.phonenumbers.PhoneMetadata} metadata
@@ -3331,10 +3329,7 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.testNumberLength_ =
 
 /**
  * Helper method to check a number against a particular pattern and determine
- * whether it matches, or is too short or too long. Currently, if a number
- * pattern suggests that numbers of length 7 and 10 are possible, and a number
- * in between these possible lengths is entered, such as of length 8, this will
- * return TOO_LONG.
+ * whether it matches, or is too short or too long.
  *
  * @param {string} number
  * @param {i18n.phonenumbers.PhoneMetadata} metadata

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -2759,6 +2759,15 @@ function testParseNationalNumber() {
   shortNumber.setCountryCode(64);
   shortNumber.setNationalNumber(12);
   assertTrue(shortNumber.equals(phoneUtil.parse('12', RegionCode.NZ)));
+
+  // Test for b/64235606. short-code with leading zero for a country which has 0
+  // as national prefix. Ensure it's not interpreted as national prefix if the
+  // remaining number length is local-only in terms of length. Example: In GB,
+  // length 6-7 are only possible local-only.
+  shortNumber.setCountryCode(44);
+  shortNumber.setNationalNumber(123456);
+  shortNumber.setItalianLeadingZero(true);
+  assertTrue(shortNumber.equals(phoneUtil.parse('0123456', RegionCode.GB)));
 }
 
 function testParseNumberWithAlphaCharacters() {

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -2760,8 +2760,8 @@ function testParseNationalNumber() {
   shortNumber.setNationalNumber(12);
   assertTrue(shortNumber.equals(phoneUtil.parse('12', RegionCode.NZ)));
 
-  // Test for b/64235606. short-code with leading zero for a country which has 0
-  // as national prefix. Ensure it's not interpreted as national prefix if the
+  // Test for short-code with leading zero for a country which has 0 as
+  // national prefix. Ensure it's not interpreted as national prefix if the
   // remaining number length is local-only in terms of length. Example: In GB,
   // length 6-7 are only possible local-only.
   shortNumber.setCountryCode(44);

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,2 +1,5 @@
 Code changes:
- - Logging changes: Don't log client-provided phone numbers.
+ - Improve parsing logic to be smarter about national-prefix detection &
+   stripping based on possible-lengths (IS_POSSIBLE_LOCAL_ONLY and
+   INVALID_LENGTH). Enables e.g. adding Iran short-codes starting with "096"
+   without the need to hack IR's national prefix parsing config.

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Logging changes: Don't log client-provided phone numbers.


### PR DESCRIPTION
Make use of the recently introduced validation enum values IS_POSSIBLE_LOCAL_ONLY and INVALID_LENGTH.
Helps with e.g. short-code parsing where the short-code's prefix matches the nationalPrefix.

E.g. Iran has nationalPrefix=0 and short-codes 096\d{2} should be added. To ensure the "0" isn't stripped (but preserved as italian_leading_zero), we need to make sure that the parser doesn't consider the 0 as the national-prefix in this number.

This already worked if:
- nationalPrefix != prefix of short-code, or
- nationalPrefix == prefix of short code and:
  - short-code matches generalDesc pattern but remainder doesn't, or
  - remainder of short-code is too short to be a non-short-code.

The last bullet item is why 112 already works as US short-code although nationalPrefix=1.

The fix is necessary for the case where the remainder (number without the national prefix) isn't too short but is possible local-only.