### PR TITLE
Add link to android-optimized port

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ However, we emphasize that these ports are by developers outside the
 libphonenumber project. We do not evaluate their quality or influence their
 maintenance processes.
 
+*   Android: Java version of libphonenumber can be used on Android as is.
+    https://github.com/MichaelRocks/libphonenumber-android is a repackaged
+    port optimized for Android by using `AssetManager#open()` instead of
+    `Class#getResourcesAsStream()` to load metadata. See [FAQ](https://github.com/googlei18n/libphonenumber/blob/master/FAQ.md#optimize-loads)
+    for why this is better
 *   C#: https://github.com/twcclegg/libphonenumber-csharp
 *   Javascript: If you don't want to use our version, which depends on Closure,
     there are several other options, including


### PR DESCRIPTION
libphonenumber-android repackages the library and replaces nonoptimal usage of `Class#getResourceAsStream()` with `AssetManager#open()` for android as suggested in [FAQ](https://github.com/googlei18n/libphonenumber/blob/e95e140dd7eeb898b9ebe1eee98ef63048ace1c0/FAQ.md#optimize-loads)