### PR TITLE
Reword known ports Android-optimized entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,15 @@ However, we emphasize that these ports are by developers outside the
 libphonenumber project. We do not evaluate their quality or influence their
 maintenance processes.
 
-*   Android: Java version of libphonenumber can be used on Android as is.
-    https://github.com/MichaelRocks/libphonenumber-android is a repackaged
-    port optimized for Android by using `AssetManager#open()` instead of
-    `Class#getResourcesAsStream()` to load metadata. See [FAQ](https://github.com/googlei18n/libphonenumber/blob/master/FAQ.md#optimize-loads)
-    for why this is better
+*   Android-optimized: If you don't want to use our Java version, which loads
+    the metadata from `Class#getResourcesAsStream` and asks that Android apps
+    follow the Android loading best practices of repackaging the metadata and
+    loading from `AssetManager#open()` themselves, as documented in our
+    [FAQ](https://github.com/googlei18n/libphonenumber/blob/master/FAQ.md#optimize-loads),
+    check out the port at https://github.com/MichaelRocks/libphonenumber-android
+    which does repackage the metadata and use `AssetManager#open()`, and may be
+    depended on without needing those specific loading optimizations from
+    clients.
 *   C#: https://github.com/twcclegg/libphonenumber-csharp
 *   Javascript: If you don't want to use our version, which depends on Closure,
     there are several other options, including


### PR DESCRIPTION
*   Android -> Android-optimized: since Android is not a language, unlike other entries in the list
*   Changed the structure of the paragraph to be closer to the Javascript paragraph's style
*   Explained in more detail how our version is different
*   Made it less ambiguous - e.g. "can be used as-is" is true of both versions, and they each come with caveats. Also we don't vet ports so don't promise anything on our own page. Also clients still need to make sure they don't call PhoneNumberUtil on the main thread, with either version.