### PR TITLE
Update kMaxNumberType stop condition

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -298,7 +298,7 @@ void GetSupportedTypesForMetadata(
     const PhoneMetadata& metadata,
     std::set<PhoneNumberUtil::PhoneNumberType>* types) {
   DCHECK(types);
-  for (int i = 0; i < static_cast<int>(PhoneNumberUtil::kMaxNumberType); ++i) {
+  for (int i = 0; i <= static_cast<int>(PhoneNumberUtil::kMaxNumberType); ++i) {
     PhoneNumberUtil::PhoneNumberType type =
         static_cast<PhoneNumberUtil::PhoneNumberType>(i);
     if (type == PhoneNumberUtil::FIXED_LINE_OR_MOBILE ||


### PR DESCRIPTION
This was not a bug (yet). The result won't change so I'm not including it in release notes.
This wasn't causing issues because UNKNOWN is actually the last value of PhoneNumberType, so the conditional at line 305 was just never true. However we introduced kMaxNumberType to be able to add new PhoneNumberType values more easily, and if we do, the new last value would not be included in the for loop (at that point there would be a bug), so fixing it now.

cl/172101896