### PR TITLE
Update 234.txt

### DIFF
--- a/resources/carrier/en/234.txt
+++ b/resources/carrier/en/234.txt
@@ -185,7 +185,7 @@
 234806|MTN
 234807|Glo
 234808|Airtel
-234809|Etisalat
+234809|9mobile
 234810|MTN
 234811|Glo
 234812|Airtel
@@ -193,8 +193,8 @@
 234814|MTN
 234815|Glo
 234816|MTN
-234817|Etisalat
-234818|Etisalat
+234817|9mobile
+234818|9mobile
 2348190|Starcomms
 2348191|Starcomms
 2348283|Starcomms
@@ -254,7 +254,7 @@
 234905|Glo
 234906|MTN
 234907|Airtel
-234908|Etisalat
-234909|Etisalat
+234908|9mobile
+234909|9mobile
 234980|Starcomms
 234987|Starcomms


### PR DESCRIPTION
Updated mobile operator name from **Etisalat** to **9mobile**.

See http://techcabal.com/2017/07/21/etisalat-nigeria-becomes-9mobile/ and http://www.ncc.gov.ng/technology/standards/numbering#mobile-telephony-number-allocation