### PR TITLE
Update Javadoc for PhoneNumberUtil.PhoneNumberFormat enum reg E.123 format rules we follow

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.h
+++ b/cpp/src/phonenumbers/phonenumberutil.h
@@ -69,14 +69,15 @@ class PhoneNumberUtil : public Singleton<PhoneNumberUtil> {
   static const char kRegionCodeForNonGeoEntity[];
 
   // INTERNATIONAL and NATIONAL formats are consistent with the definition
-  // in ITU-T Recommendation E. 123. For example, the number of the Google
-  // Zürich office will be written as "+41 44 668 1800" in INTERNATIONAL
-  // format, and as "044 668 1800" in NATIONAL format. E164 format is as per
-  // INTERNATIONAL format but with no formatting applied e.g. "+41446681800".
-  // RFC3966 is as per INTERNATIONAL format, but with all spaces and other
-  // separating symbols replaced with a hyphen, and with any phone number
-  // extension appended with ";ext=". It also will have a prefix of "tel:"
-  // added, e.g. "tel:+41-44-668-1800".
+  // in ITU-T Recommendation E.123. However we follow local conventions such as
+  // using '-' instead of whitespace as separators. For example, the number of
+  // the Google Switzerland office will be written as "+41 44 668 1800" in
+  // INTERNATIONAL format, and as "044 668 1800" in NATIONAL format. E164
+  // format is as per INTERNATIONAL format but with no formatting applied e.g.
+  // "+41446681800". RFC3966 is as per INTERNATIONAL format, but with all spaces
+  // and other separating symbols replaced with a hyphen, and with any phone
+  // number extension appended with ";ext=". It also will have a prefix of
+  // "tel:" added, e.g. "tel:+41-44-668-1800".
   enum PhoneNumberFormat {
     E164,
     INTERNATIONAL,

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -389,7 +389,7 @@ public class PhoneNumberUtil {
    * will have a prefix of "tel:" added, e.g. "tel:+41-44-668-1800".
    *
    * Note: If you are considering storing the number in a neutral format, you are highly advised to
-   * use the phonenumber.proto. For details, see http://go/phone-pb
+   * use the PhoneNumber class.
    */
   public enum PhoneNumberFormat {
     E164,

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java
@@ -380,15 +380,16 @@ public class PhoneNumberUtil {
 
   /**
    * INTERNATIONAL and NATIONAL formats are consistent with the definition in ITU-T Recommendation
-   * E123. For example, the number of the Google Switzerland office will be written as
-   * "+41 44 668 1800" in INTERNATIONAL format, and as "044 668 1800" in NATIONAL format.
-   * E164 format is as per INTERNATIONAL format but with no formatting applied, e.g.
-   * "+41446681800". RFC3966 is as per INTERNATIONAL format, but with all spaces and other
-   * separating symbols replaced with a hyphen, and with any phone number extension appended with
-   * ";ext=". It also will have a prefix of "tel:" added, e.g. "tel:+41-44-668-1800".
+   * E.123. However we follow local conventions such as using '-' instead of whitespace as
+   * separators. For example, the number of the Google Switzerland office will be written as
+   * "+41 44 668 1800" in INTERNATIONAL format, and as "044 668 1800" in NATIONAL format. E164
+   * format is as per INTERNATIONAL format but with no formatting applied, e.g. "+41446681800".
+   * RFC3966 is as per INTERNATIONAL format, but with all spaces and other separating symbols
+   * replaced with a hyphen, and with any phone number extension appended with ";ext=". It also
+   * will have a prefix of "tel:" added, e.g. "tel:+41-44-668-1800".
    *
    * Note: If you are considering storing the number in a neutral format, you are highly advised to
-   * use the PhoneNumber class.
+   * use the phonenumber.proto. For details, see http://go/phone-pb
    */
   public enum PhoneNumberFormat {
     E164,

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -883,14 +883,15 @@ i18n.phonenumbers.PhoneNumberUtil.REGION_CODE_FOR_NON_GEO_ENTITY = '001';
 
 /**
  * INTERNATIONAL and NATIONAL formats are consistent with the definition in
- * ITU-T Recommendation E123. For example, the number of the Google Switzerland
- * office will be written as '+41 44 668 1800' in INTERNATIONAL format, and as
- * '044 668 1800' in NATIONAL format. E164 format is as per INTERNATIONAL format
- * but with no formatting applied, e.g. '+41446681800'. RFC3966 is as per
- * INTERNATIONAL format, but with all spaces and other separating symbols
- * replaced with a hyphen, and with any phone number extension appended with
- * ';ext='. It also will have a prefix of 'tel:' added, e.g.
- * 'tel:+41-44-668-1800'.
+ * ITU-T Recommendation E123. However we follow local conventions such as
+ * using '-' instead of whitespace as separators. For example, the number of the
+ * Google Switzerland office will be written as '+41 44 668 1800' in
+ * INTERNATIONAL format, and as '044 668 1800' in NATIONAL format. E164 format
+ * is as per INTERNATIONAL format but with no formatting applied, e.g.
+ * '+41446681800'. RFC3966 is as per INTERNATIONAL format, but with all spaces
+ * and other separating symbols replaced with a hyphen, and with any phone
+ * number extension appended with ';ext='. It also will have a prefix of 'tel:'
+ * added, e.g. 'tel:+41-44-668-1800'.
  *
  * Note: If you are considering storing the number in a neutral format, you are
  * highly advised to use the PhoneNumber class.


### PR DESCRIPTION
We say that "INTERNATIONAL and NATIONAL formats are consistent with the definition in ITU-T Recommendation E.123." This is not completely true as we follow local conventions which can include using '-' instead of whitespace (Mentioned in E.123 doc) as separators. PTAL at attached bug for more details.