### PR TITLE
Carrier metadata update for BA - 387 (en)

### DIFF
--- a/resources/carrier/en/387.txt
+++ b/resources/carrier/en/387.txt
@@ -12,19 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-38760|BH Mobile
-38761|BH Mobile
-38762|BH Mobile
-38763|HT-ERONET
-3876440|HT-ERONET
-3876441|HT-ERONET
-3876442|HT-ERONET
-3876443|HT-ERONET
-3876444|HT-ERONET
-3876445|HT-ERONET
-3876446|HT-ERONET
+
+# 387 - Bosnia & Herzegovina
+
+# Source(s):
+# -----------------------
+# RAK: http://rak.ba/eng/index.php?uid=1283438061
+# -----------------------
+
+# Carriers:
+# -----------------------
+# BH Telecom: bhtelecom.ba - BH Telecom d.d. Sarajevo
+# m:tel: mtel.ba - Mtel a.d. Banja Luka
+# HT ERONET: hteronet.ba - Hrvatske telekomunikacije d.d. Mostar
+# -----------------------
+
+# -----------------------
+# Last checked: 6/12/2017
+# Last updated: 6/12/2017
+# -----------------------
+
+38760|BH Telecom
+38761|BH Telecom
+38762|BH Telecom
+38763|HT ERONET
+38764|HT ERONET
 38765|m:tel
 38766|m:tel
-3876711|m:tel
-3876713|m:tel
-3876717|m:tel
+38767|m:tel


### PR DESCRIPTION
- BH Mobile is BH Telecom
- HT-ERONET without the hyphen HT ERONET