### PR TITLE
Carrier metadata update for MK - 389 (en)

### DIFF
--- a/resources/carrier/en/389.txt
+++ b/resources/carrier/en/389.txt
@@ -12,26 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-38970|T-Mobile
-38971|T-Mobile
-38972|T-Mobile
-389732|Albafone
-3897421|Mobik Telekomunikacii
-38975|one.Vip
-38976|one.Vip
-38977|one.Vip
-38978|one.Vip
-389792|one.Vip
-3897930|one.Vip
-3897931|one.Vip
-3897932|one.Vip
-3897933|one.Vip
-3897934|one.Vip
-3897935|one.Vip
-3897936|one.Vip
-38979370|one.Vip
-38979371|one.Vip
-38979372|one.Vip
-38979373|one.Vip
-38979374|one.Vip
-38979375|one.Vip
+
+# 389 - Macedonia
+
+# Source(s):
+# -----------------------
+# AEK: https://e-agencija.aek.mk/aek-crm-portal/Pages/Public/PublicFreeSeries/PublicFreeSeries
+# -----------------------
+
+# Carriers:
+# -----------------------
+# Telekom: telekom.mk - Makedonski Telekom AD - Skopje
+# Vip: vip.mk - one.Vip DOOEL Skopje
+# Lycamobile: lycamobile.mk - Lycamobile DOOEL Skopje
+# Mobik: mobik.mk - Mobik Telekomunikacii DOOEL
+# -----------------------
+
+# -----------------------
+# Last checked: 6/12/2017
+# Last updated: 6/12/2017
+# -----------------------
+
+38970|Telekom
+38971|Telekom
+38972|Telekom
+389732|Vip
+389733|Telekom
+389734|Vip
+3897421|Mobik
+38975|Vip
+38976|Vip
+38977|Vip
+38978|Vip
+38979|Lycamobile


### PR DESCRIPTION
- T-Mobile rebranded as Telekom: 
https://en.wikipedia.org/wiki/Makedonski_Telekom
- one.Vip rebranded as Vip: 
https://en.wikipedia.org/wiki/ONE.VIP
- Albafone no longer active:
 https://www.facebook.com/ALBAFONE.MK/posts/659478154182505
- Mobik Telekomunikacii no longer seems to be active, however the range allocated to them is still displayed under their registered company.