### PR TITLE
Geocode metadata for XK - 383 (en)

### DIFF
--- a/resources/geocoding/en/383.txt
+++ b/resources/geocoding/en/383.txt
@@ -1,0 +1,34 @@
+# Copyright (C) 2017 The Libphonenumber Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# 383 - Kosovo
+
+# Source(s):
+# ------------------------
+# ARKEP, National Numbering Plan: http://www.arkep-rks.org/?cid=1,48,742
+# ------------------------
+
+# ------------------------
+# Last checked: 18/12/2017
+# Last updated: 18/12/2017
+# ------------------------
+
+38328|Mitrovica
+38329|Prizren
+38338|Prishtina
+38339|Peja
+383280|Gjilan
+383290|Ferizaj
+383390|Gjakova


### PR DESCRIPTION
The order is correct, first four are 2 digit and last three ones are 3 digit region codes. The separation is easy since no region code can have a following 0 after the prefix. Wil the regex handle this or should the 2 digit codes be expanded?