### PR TITLE
Carrier metadata update for CH

### DIFF
--- a/resources/carrier/en/41.txt
+++ b/resources/carrier/en/41.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+4175|Swisscom
 4176|Sunrise
 4177|Tele4u
 4178|Salt


### PR DESCRIPTION
+4175 should be supported as a valid carrier number since mid 2016

see https://www.swisscom.ch/en/about/medien/press-releases/2015/07/20150714-MM-075-ist-neue-Vorwahl.html