### PR TITLE
Introduce 456 mobile range for Belgium

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -2764,6 +2764,7 @@
         <exampleNumber>470123456</exampleNumber>
         <nationalNumberPattern>
           4(?:
+            5[6]|
             6[0135-8]|
             [79]\d|
             8[3-9]


### PR DESCRIPTION
Unleashed is a new FMVNO on the Belgian market that operates under the 456 range.
Updates have been made to the BIPT information to reflect this.
These can be found following the BE information on the ITU website (change of 1/1/2018):
http://www.itu.int/oth/default.aspx?lang=en&parent=T0202000015

I have an official IR.21 available in case anyone needs extra proof and I can be reached on one of these new numbers myself.