### PR TITLE
Update FALSEHOODS.md

### DIFF
--- a/FALSEHOODS.md
+++ b/FALSEHOODS.md
@@ -50,7 +50,7 @@ surprising how many false assumptions programmers continue to make about them.
 
     As of this present moment (in Mar. 2016), phones in the disputed territory
     and partially recognised state of Kosovo may be reached by dialing the
-    country calling code for Serbia (+381), Slovenia (+386), or Monaco (+377),
+    country calling code for Serbia (+381), Slovenia (+386), or, strangely enough, Monaco (+377),
     depending on where and when one obtained the number.
 
     **Tip:** Use a phone widget to encourage users to enter their phone number


### PR DESCRIPTION
Update: Each country has only one country calling code
Seeing Monaco here is a surprise because it is a country 1500 to the west. I expected that it was a mistake and it should have been Kosovos neighbor, Macedonia. But no, Monaco is right. This should be highlighted.