### PR TITLE
Updated Mongolian carrier prefixes

### DIFF
--- a/resources/carrier/en/976.txt
+++ b/resources/carrier/en/976.txt
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 97680|Unitel
-976830|G-Mobile
-976831|G-Mobile
+97683|G-Mobile
 97685|Mobicom
 97686|Unitel
 97688|Unitel
 97689|Unitel
+97690|Skytel
+97691|Skytel
+97693|G-Mobile
+97694|Mobicom
+97695|Mobicom
+97696|Skytel
+97698|G-Mobile
+97699|Mobicom

--- a/resources/carrier/en/976.txt
+++ b/resources/carrier/en/976.txt
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 97680|Unitel
-97683|G-Mobile
+976830|G-Mobile
+976831|G-Mobile
 97685|Mobicom
 97686|Unitel
 97688|Unitel


### PR DESCRIPTION
Updated from Communications Regulatory Commission of Mongolian.
http://www.crc.gov.mn/k/4L/36

Another source: http://www.wtng.info/wtng-976-mn.html