### PR TITLE
Add typecast for prefixMatcher in JS library

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -3868,8 +3868,8 @@ i18n.phonenumbers.PhoneNumberUtil.prototype.
   // Attempt to parse the first digits as a national prefix.
   /** @type {!RegExp} */
   var prefixPattern = new RegExp('^(?:' + possibleNationalPrefix + ')');
-  /** @type {Array.<string>} */
-  var prefixMatcher = prefixPattern.exec(numberStr);
+  var prefixMatcher = /** @type {?Array<string>} */ (
+      prefixPattern.exec(numberStr));
   if (prefixMatcher) {
     /** @type {!RegExp} */
     var nationalNumberRule = new RegExp(

--- a/pending_code_changes.txt
+++ b/pending_code_changes.txt
@@ -1,1 +1,2 @@
-
+Code changes:
+ - Add typecast for prefixMatcher in JS library.


### PR DESCRIPTION
cl/192841937

No build artifacts are affected with this change.

`tools/java/cpp-build/target/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar` and `tools/java/java-build/target/java-build-1.0-SNAPSHOT-jar-with-dependencies.jar` are already outdated in `master`, but I haven't checked whether those changes contain build tools, and I'm not addressing those here.