### PR TITLE
Add support for VOO Mobile (Nethys SA) in Belgium - 455 number range

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -2847,7 +2847,7 @@
         <exampleNumber>470123456</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            56|
+            5[56]|
             6[0135-8]|
             [79]\d|
             8[3-9]

--- a/resources/carrier/en/32.txt
+++ b/resources/carrier/en/32.txt
@@ -19,6 +19,7 @@
 # phone numbers are mentioned in contact-us page of JIM mobile carrier. So it is
 # more likely that it is assigned to 'JIM Mobile'
 
+32455|VOO Mobile (Nethys SA)
 32456|JIM Mobile
 32460|Proximus
 324618|N.M.B.S.


### PR DESCRIPTION
VOO Mobile (Nethys SA) has the +32455\d{6} range in Belgium

See http://www.bipt.be/en/operators/telecommunication/Numbering/Database/database-with-reserved-and-allocated-numbers