### PR TITLE
Manually support unicode version of Russian extension characters доб in RegEx

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -780,7 +780,7 @@ i18n.phonenumbers.PhoneNumberUtil.EXTN_PATTERNS_FOR_PARSING_ =
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '|' +
     '[ \u00A0\\t,]*' +
     '(?:e?xt(?:ensi(?:o\u0301?|\u00F3))?n?|\uFF45?\uFF58\uFF54\uFF4E?|' +
-    'доб|' +
+    'доб|\u0434\u043E\u0431|ДОБ|' +
     '[;,x\uFF58#\uFF03~\uFF5E]|int|anexo|\uFF49\uFF4E\uFF54)' +
     '[:\\.\uFF0E]?[ \u00A0\\t,-]*' +
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '#?|' +

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -3463,9 +3463,16 @@ function testParseExtensions() {
   assertTrue(ruWithExtension.equals(
       phoneUtil.parse('8 (423) 202-25-11доб100',
 		      RegionCode.RU)));
+  // Testing in unicode format
+  assertTrue(ruWithExtension.equals(
+      phoneUtil.parse('8 (423) 202-25-11, \u0434\u043E\u0431. 100',
+                      RegionCode.RU)));
   // In upper case
   assertTrue(ruWithExtension.equals(
-    phoneUtil.parse('8 (423) 202-25-11\u0414\u041E\u0431100',
+    phoneUtil.parse('8 (423) 202-25-11ДОБ100',
+	               RegionCode.RU)));
+  assertTrue(ruWithExtension.equals(
+    phoneUtil.parse('8 (423) 202-25-11\u0414\u041E\u0411100',
 	               RegionCode.RU)));
 
   // Test that if a number has two extensions specified, we ignore the second.

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -3449,19 +3449,19 @@ function testParseExtensions() {
   ruWithExtension.setNationalNumber(4232022511);
   ruWithExtension.setExtension('100');
   assertTrue(ruWithExtension.equals(
-      phoneUtil.parse('8 (423) 202-25-11, \u0434\u043E\u0431. 100',
+      phoneUtil.parse('8 (423) 202-25-11, доб. 100',
                       RegionCode.RU)));
   assertTrue(ruWithExtension.equals(
-      phoneUtil.parse('8 (423) 202-25-11 \u0434\u043E\u0431. 100',
+      phoneUtil.parse('8 (423) 202-25-11 доб. 100',
 		      RegionCode.RU)));
   assertTrue(ruWithExtension.equals(
-      phoneUtil.parse('8 (423) 202-25-11, \u0434\u043E\u0431 100',
+      phoneUtil.parse('8 (423) 202-25-11, доб 100',
 		      RegionCode.RU)));
   assertTrue(ruWithExtension.equals(
-      phoneUtil.parse('8 (423) 202-25-11 \u0434\u043E\u0431 100',
+      phoneUtil.parse('8 (423) 202-25-11 доб 100',
 		      RegionCode.RU)));
   assertTrue(ruWithExtension.equals(
-      phoneUtil.parse('8 (423) 202-25-11\u0434\u043E\u0431100',
+      phoneUtil.parse('8 (423) 202-25-11доб100',
 		      RegionCode.RU)));
   // In upper case
   assertTrue(ruWithExtension.equals(
@@ -3651,7 +3651,7 @@ function testIsNumberMatchMatches() {
   assertEquals(i18n.phonenumbers.PhoneNumberUtil.MatchType.EXACT_MATCH,
                  phoneUtil.isNumberMatch(
 		     '+7 423 202-25-11 ext 100',
-		     '+7 4232022511 \u0434\u043E\u0431. 100'));
+		     '+7 4232022511 доб. 100'));
   // Test proto buffers.
   assertEquals(i18n.phonenumbers.PhoneNumberUtil.MatchType.EXACT_MATCH,
                phoneUtil.isNumberMatch(NZ_NUMBER, '+6403 331 6005'));


### PR DESCRIPTION
Presently we are supporting unicode characters of Russian extension characters manually in JS.
This should be changed in future by setting right flags.
Previous PR: https://github.com/googlei18n/libphonenumber/pull/2223

Surprisingly, we need not set unicode characters of upper case '\u0414\u041E\u0411'. This woks fine.