### PR TITLE
Ensure the test runner decodes files as UTF-8

### DIFF
--- a/javascript/i18n/phonenumbers/asyoutypeformatter_test.html
+++ b/javascript/i18n/phonenumbers/asyoutypeformatter_test.html
@@ -20,6 +20,7 @@ limitations under the License.
   Author: Nikolaos Trogkanis
 -->
 <head>
+<meta charset="utf-8">
 <title>libphonenumber Unit Tests - i18n.phonenumbers - asyoutypeformatter.js</title>
 <script src="../../../../closure-library/closure/goog/base.js"></script>
 <script>

--- a/javascript/i18n/phonenumbers/demo-compiled.html
+++ b/javascript/i18n/phonenumbers/demo-compiled.html
@@ -20,6 +20,7 @@ limitations under the License.
   Author: Nikolaos Trogkanis
 -->
 <head>
+<meta charset="utf-8">
 <title>Phone Number Parser Demo</title>
 <script src="demo-compiled.js"></script>
 </head>

--- a/javascript/i18n/phonenumbers/demo.html
+++ b/javascript/i18n/phonenumbers/demo.html
@@ -20,6 +20,7 @@ limitations under the License.
   Author: Nikolaos Trogkanis
 -->
 <head>
+<meta charset="utf-8">
 <title>Phone Number Parser Demo</title>
 <script src="../../../../closure-library/closure/goog/base.js"></script>
 <script>

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -780,7 +780,7 @@ i18n.phonenumbers.PhoneNumberUtil.EXTN_PATTERNS_FOR_PARSING_ =
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '|' +
     '[ \xA0\\t,]*' +
     '(?:e?xt(?:ensi(?:o\u0301?|\u00F3))?n?|\uFF45?\uFF58\uFF54\uFF4E?|' +
-    'доб|ДОБ|' + // '\u0434\u043E\u0431|\u0414\u041E\u0411'
+    '\u0434\u043E\u0431|\u0414\u041E\u0411|' +
     '[;,x\uFF58#\uFF03~\uFF5E]|int|anexo|\uFF49\uFF4E\uFF54)' +
     '[:\\.\uFF0E]?[ \xA0\\t,-]*' +
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '#?|' +

--- a/javascript/i18n/phonenumbers/phonenumberutil.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil.js
@@ -778,11 +778,11 @@ i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ =
 i18n.phonenumbers.PhoneNumberUtil.EXTN_PATTERNS_FOR_PARSING_ =
     i18n.phonenumbers.PhoneNumberUtil.RFC3966_EXTN_PREFIX_ +
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '|' +
-    '[ \u00A0\\t,]*' +
+    '[ \xA0\\t,]*' +
     '(?:e?xt(?:ensi(?:o\u0301?|\u00F3))?n?|\uFF45?\uFF58\uFF54\uFF4E?|' +
-    'доб|\u0434\u043E\u0431|ДОБ|' +
+    'доб|ДОБ|' + // '\u0434\u043E\u0431|\u0414\u041E\u0411'
     '[;,x\uFF58#\uFF03~\uFF5E]|int|anexo|\uFF49\uFF4E\uFF54)' +
-    '[:\\.\uFF0E]?[ \u00A0\\t,-]*' +
+    '[:\\.\uFF0E]?[ \xA0\\t,-]*' +
     i18n.phonenumbers.PhoneNumberUtil.CAPTURING_EXTN_DIGITS_ + '#?|' +
     '[- ]+([' + i18n.phonenumbers.PhoneNumberUtil.VALID_DIGITS_ + ']{1,5})#';
 

--- a/javascript/i18n/phonenumbers/phonenumberutil_test.html
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.html
@@ -20,6 +20,7 @@ limitations under the License.
   Author: Nikolaos Trogkanis
 -->
 <head>
+<meta charset="utf-8">
 <title>libphonenumber Unit Tests - i18n.phonenumbers - phonenumberutil.js</title>
 <script src="../../../../closure-library/closure/goog/base.js"></script>
 <script>

--- a/javascript/i18n/phonenumbers/shortnumberinfo_test.html
+++ b/javascript/i18n/phonenumbers/shortnumberinfo_test.html
@@ -20,6 +20,7 @@ limitations under the License.
   Author: Nikolaos Trogkanis
 -->
 <head>
+<meta charset="utf-8">
 <title>libphonenumber Unit Tests - i18n.phonenumbers - shortnumberinfo.js</title>
 <script src="../../../../closure-library/closure/goog/base.js"></script>
 <script>


### PR DESCRIPTION
Before this change, the `document.charset` of the HTML test files would be 'windows-1252' when accessed through the `file://` protocol, resulting in issues with library or test files containing non-ASCII symbols.

This patch ensures tests still run correctly when files contain non-ASCII symbols.