### PR TITLE
Configuring not to close staging repo automatically after pushing staging binaries to Sonatype

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -168,6 +168,7 @@
           <serverId>sonatype-nexus-staging</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <stagingProfileId>23ed8fbc71e875</stagingProfileId>
+	  <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- Issue: Staging repo is getting closed immediately after pushing staging binaries to Sonatype (i.e after running mvn release:perform). As per our mvn process / commands it should create an open staging repo and we close them manually after creating Maven PR like #2255. 
Note: This is to ensure the staging repo still in open state (to make any corrections/rerun) if anything is gone wrong in final steps of Maven release.

- History: This started happening after our introduction of nexus-staging-maven-plugin to avoid multiple staging repo are getting created in Sonatype. PR #2236

- Solution: Setting <skipStagingRepositoryClose> to true for same nexus-staging-maven-plugin
More details in and this solution is suggested at: https://issues.sonatype.org/browse/OSSRH-41613
Documentation referred: https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment
 
- Testing: This should solve the issue. However we can only verify it in our next release (probably 8.9.14)