### PR TITLE
added back Zapp network numbers

### DIFF
--- a/resources/carrier/en/40.txt
+++ b/resources/carrier/en/40.txt
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Prefixes 78[08] were previously assigned to zapp.ro (TELEMOBIL S.A.) but they
-# are no longer operational and we are not aware to which operator it is
-# currently assigned.
-
 407000|Enigma-System
 407013|Lycamobile
 407014|Lycamobile
@@ -40,9 +36,11 @@
 40774|Digi Mobil
 40775|Digi Mobil
 40776|Digi Mobil
+40780|Telekom
 40783|Telekom
 40784|Telekom
 40785|Telekom
 40786|Telekom
 40787|Telekom
+40788|Telekom
 40799|Vodafone


### PR DESCRIPTION
Zapp was bought by Telekom. 
https://en.wikipedia.org/wiki/Zapp_Mobile

And for example, 07887xxxxx is still a valid number.