### PR TITLE
Update ShortNumberInfo test regarding example number change.

### DIFF
--- a/cpp/test/phonenumbers/shortnumberinfo_test.cc
+++ b/cpp/test/phonenumbers/shortnumberinfo_test.cc
@@ -299,7 +299,7 @@ TEST_F(ShortNumberInfoTest, GetExpectedCostForSharedCountryCallingCode) {
 }
 
 TEST_F(ShortNumberInfoTest, GetExampleShortNumber) {
-  EXPECT_EQ("8711", short_info_.GetExampleShortNumber(RegionCode::AM()));
+  EXPECT_EQ("110", short_info_.GetExampleShortNumber(RegionCode::AD()));
   EXPECT_EQ("1010", short_info_.GetExampleShortNumber(RegionCode::FR()));
   EXPECT_EQ("", short_info_.GetExampleShortNumber(RegionCode::UN001()));
   EXPECT_EQ("", short_info_.GetExampleShortNumber(RegionCode::GetUnknown()));

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/ShortNumberInfoTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/ShortNumberInfoTest.java
@@ -195,7 +195,7 @@ public class ShortNumberInfoTest extends TestMetadataTestCase {
   }
 
   public void testGetExampleShortNumber() {
-    assertEquals("8711", shortInfo.getExampleShortNumber(RegionCode.AM));
+    assertEquals("100", shortInfo.getExampleShortNumber(RegionCode.AM));
     assertEquals("1010", shortInfo.getExampleShortNumber(RegionCode.FR));
     assertEquals("", shortInfo.getExampleShortNumber(RegionCode.UN001));
     assertEquals("", shortInfo.getExampleShortNumber(null));

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/ShortNumberInfoTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/ShortNumberInfoTest.java
@@ -195,7 +195,7 @@ public class ShortNumberInfoTest extends TestMetadataTestCase {
   }
 
   public void testGetExampleShortNumber() {
-    assertEquals("100", shortInfo.getExampleShortNumber(RegionCode.AM));
+    assertEquals("110", shortInfo.getExampleShortNumber(RegionCode.AD));
     assertEquals("1010", shortInfo.getExampleShortNumber(RegionCode.FR));
     assertEquals("", shortInfo.getExampleShortNumber(RegionCode.UN001));
     assertEquals("", shortInfo.getExampleShortNumber(null));

--- a/javascript/i18n/phonenumbers/shortnumberinfo_test.js
+++ b/javascript/i18n/phonenumbers/shortnumberinfo_test.js
@@ -271,7 +271,7 @@ function testGetExpectedCostForSharedCountryCallingCode() {
 }
 
 function testGetExampleShortNumber() {
-  assertEquals('8711', shortInfo.getExampleShortNumber(RegionCode.AM));
+  assertEquals('110', shortInfo.getExampleShortNumber(RegionCode.AD));
   assertEquals('1010', shortInfo.getExampleShortNumber(RegionCode.FR));
   assertEquals('', shortInfo.getExampleShortNumber(RegionCode.UN001));
   assertEquals('', shortInfo.getExampleShortNumber(null));


### PR DESCRIPTION
Update ShortNumberInfo test regarding example number change for region AM. Unlike PhoneNumberUtilTest, ShortNumberInfoTest uses real metadata for unit testing.