### PR TITLE
Reverting version number updates in pom.xml, done in PR #2277

### DIFF
--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>carrier</artifactId>
-  <version>1.97-SNAPSHOT</version>
+  <version>1.96-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.1-SNAPSHOT</version>
+    <version>8.9.17-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.1-SNAPSHOT</version>
+      <version>8.9.17-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.107-SNAPSHOT</version>
+      <version>2.106-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>demo</artifactId>
-  <version>8.10.1-SNAPSHOT</version>
+  <version>8.9.17-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.1-SNAPSHOT</version>
+    <version>8.9.17-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -88,17 +88,17 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.1-SNAPSHOT</version>
+      <version>8.9.17-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>geocoder</artifactId>
-      <version>2.107-SNAPSHOT</version>
+      <version>2.106-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>carrier</artifactId>
-      <version>1.97-SNAPSHOT</version>
+      <version>1.96-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>geocoder</artifactId>
-  <version>2.107-SNAPSHOT</version>
+  <version>2.106-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.1-SNAPSHOT</version>
+    <version>8.9.17-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -64,12 +64,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.1-SNAPSHOT</version>
+      <version>8.9.17-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.107-SNAPSHOT</version>
+      <version>2.106-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/internal/prefixmapper/pom.xml
+++ b/java/internal/prefixmapper/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>prefixmapper</artifactId>
-  <version>2.107-SNAPSHOT</version>
+  <version>2.106-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.1-SNAPSHOT</version>
+    <version>8.9.17-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.1-SNAPSHOT</version>
+      <version>8.9.17-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
-  <version>8.10.1-SNAPSHOT</version>
+  <version>8.9.17-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.1-SNAPSHOT</version>
+    <version>8.9.17-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber-parent</artifactId>
-  <version>8.10.1-SNAPSHOT</version>
+  <version>8.9.17-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 


### PR DESCRIPTION
- The Maven release is started before the merge of metadata update (PR #2276).
- So reverting the pom.xml updates and starting over Maven release again.