### PR TITLE
Penmetsaa maven update

### DIFF
--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>carrier</artifactId>
-  <version>1.96-SNAPSHOT</version>
+  <version>1.96</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.9.17-SNAPSHOT</version>
+    <version>8.10.0</version>
   </parent>
 
   <build>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.9.17-SNAPSHOT</version>
+      <version>8.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.106-SNAPSHOT</version>
+      <version>2.106</version>
     </dependency>
   </dependencies>
 

--- a/java/carrier/pom.xml
+++ b/java/carrier/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>carrier</artifactId>
-  <version>1.96</version>
+  <version>1.97-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.0</version>
+    <version>8.10.1-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.0</version>
+      <version>8.10.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.106</version>
+      <version>2.107-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>demo</artifactId>
-  <version>8.10.0</version>
+  <version>8.10.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.0</version>
+    <version>8.10.1-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -88,17 +88,17 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.0</version>
+      <version>8.10.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>geocoder</artifactId>
-      <version>2.106</version>
+      <version>2.107-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>carrier</artifactId>
-      <version>1.96</version>
+      <version>1.97-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>demo</artifactId>
-  <version>8.9.17-SNAPSHOT</version>
+  <version>8.10.0</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.9.17-SNAPSHOT</version>
+    <version>8.10.0</version>
   </parent>
 
   <properties>
@@ -88,17 +88,17 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.9.17-SNAPSHOT</version>
+      <version>8.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>geocoder</artifactId>
-      <version>2.106-SNAPSHOT</version>
+      <version>2.106</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>carrier</artifactId>
-      <version>1.96-SNAPSHOT</version>
+      <version>1.96</version>
     </dependency>
   </dependencies>
 

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>geocoder</artifactId>
-  <version>2.106</version>
+  <version>2.107-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.0</version>
+    <version>8.10.1-SNAPSHOT</version>
   </parent>
 
   <build>
@@ -64,12 +64,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.0</version>
+      <version>8.10.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.106</version>
+      <version>2.107-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/geocoder/pom.xml
+++ b/java/geocoder/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>geocoder</artifactId>
-  <version>2.106-SNAPSHOT</version>
+  <version>2.106</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.9.17-SNAPSHOT</version>
+    <version>8.10.0</version>
   </parent>
 
   <build>
@@ -64,12 +64,12 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.9.17-SNAPSHOT</version>
+      <version>8.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>prefixmapper</artifactId>
-      <version>2.106-SNAPSHOT</version>
+      <version>2.106</version>
     </dependency>
   </dependencies>
 

--- a/java/internal/prefixmapper/pom.xml
+++ b/java/internal/prefixmapper/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>prefixmapper</artifactId>
-  <version>2.106</version>
+  <version>2.107-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.0</version>
+    <version>8.10.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.10.0</version>
+      <version>8.10.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/internal/prefixmapper/pom.xml
+++ b/java/internal/prefixmapper/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>prefixmapper</artifactId>
-  <version>2.106-SNAPSHOT</version>
+  <version>2.106</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.9.17-SNAPSHOT</version>
+    <version>8.10.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.9.17-SNAPSHOT</version>
+      <version>8.10.0</version>
     </dependency>
   </dependencies>
 

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
-  <version>8.10.0</version>
+  <version>8.10.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.10.0</version>
+    <version>8.10.1-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
-  <version>8.9.17-SNAPSHOT</version>
+  <version>8.10.0</version>
   <packaging>jar</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
   <parent>
     <groupId>com.googlecode.libphonenumber</groupId>
     <artifactId>libphonenumber-parent</artifactId>
-    <version>8.9.17-SNAPSHOT</version>
+    <version>8.10.0</version>
   </parent>
 
   <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber-parent</artifactId>
-  <version>8.9.17-SNAPSHOT</version>
+  <version>8.10.0</version>
   <packaging>pom</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
@@ -34,7 +34,7 @@
     <connection>scm:git:https://github.com/googlei18n/libphonenumber.git</connection>
     <developerConnection>scm:git:git@github.com:googlei18n/libphonenumber.git</developerConnection>
     <url>https://github.com/googlei18n/libphonenumber/</url>
-    <tag>HEAD</tag>
+    <tag>v8.10.0</tag>
   </scm>
 
   <properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber-parent</artifactId>
-  <version>8.10.0</version>
+  <version>8.10.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/googlei18n/libphonenumber/</url>
 
@@ -34,7 +34,7 @@
     <connection>scm:git:https://github.com/googlei18n/libphonenumber.git</connection>
     <developerConnection>scm:git:git@github.com:googlei18n/libphonenumber.git</developerConnection>
     <url>https://github.com/googlei18n/libphonenumber/</url>
-    <tag>v8.10.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
The same previous update #2277 is reverted in #2280.
This is new roll-forward of original pom.xml updates.