### PR TITLE
Regenerate GB carrier data

### DIFF
--- a/resources/carrier/en/44.txt
+++ b/resources/carrier/en/44.txt
@@ -13,26 +13,23 @@
 # limitations under the License.
 
 # Carrier details updated from http://www.ofcom.org.uk/static/numbering/S7.xls
-# Generated on 2017-07-14 using https://github.com/giggsey/GBCarrierGenerator
+# Generated on 2018-11-13 using https://github.com/giggsey/GBCarrierGenerator
 
 # Carrier names have been updated to friendlier trading/brand names.
 # The mapping of company names can be found below:
 #  - (aq) Limited trading as aql: aql
 #  - 08Direct Limited: 08Direct
-#  - 09 Mobile Ltd: 09 Mobile
 #  - 24 Seven Communications Ltd: 24 Seven
-#  - AMSUK LTD: AMSUK
 #  - Ace Call Limited: Ace Call
 #  - Airwave Solutions Ltd: Airwave
-#  - Alliance Technologies LLC: Alliance
 #  - Andrews & Arnold Ltd: Andrews & Arnold
 #  - Anywhere Sim Limited: Anywhere Sim
 #  - BT OnePhone Limited: BT OnePhone
 #  - Bellingham Telecommunications Limited: Bellingham
+#  - Bluewave Communications Limited: Bluewave Communications
 #  - CFL Communications Limited: CFL
 #  - Cheers International Sales Limited: Cheers
 #  - Citrus Telecommunications Ltd: Citrus
-#  - Cloud9 Communications Limited: Cloud9
 #  - Cloud9 Mobile Communications Ltd: Cloud9
 #  - Compatel Ltd: Compatel
 #  - Confabulate Limited: Confabulate
@@ -53,13 +50,11 @@
 #  - Hutchison 3G UK Ltd: Three
 #  - IPV6 Limited: IPV6
 #  - IV Response Limited: IV Response
-#  - Icron Network: Icron
 #  - Icron Network Limited: Icron Network
 #  - JT (Guernsey) Limited: JT
 #  - JT (Jersey) Limited: JT
 #  - Jersey Airtel  Limited: Airtel
 #  - Lanonyx Telecom Limited: Lanonyx
-#  - LegendTel LLC: LegendTel
 #  - Limitless Mobile Ltd: Limitless
 #  - Lleida.net Serveis Telematics Limited: Lleida.net
 #  - Lycamobile UK Limited: Lycamobile
@@ -74,11 +69,11 @@
 #  - Nodemax Limited: Nodemax
 #  - PageOne Communications Ltd: PageOne
 #  - Plus Telecom Limited: Plus
-#  - Premium O Limited: Premium O
 #  - Premium Routing GmbH: Premium Routing
 #  - QX Telecom Ltd: QX Telecom
 #  - Relax Telecom Limited: Relax
 #  - Resilient Plc: Resilient
+#  - Simetric Telecom Ltd: Simetric Telecom
 #  - Simwood eSMS Limited: Simwood
 #  - Sky UK Limited: Sky
 #  - Sound Advertising Ltd: Mediatel
@@ -91,7 +86,6 @@
 #  - Synectiv Ltd: Synectiv
 #  - Syntec Limited: Syntec
 #  - TGL Services (UK) Ltd: TGL
-#  - TalkTalk Communications Limited: TalkTalk
 #  - TeleWare PLC: TeleWare
 #  - Telecom 10 Ltd: Telecom 10
 #  - Telecom North America Mobile Inc: Telna
@@ -99,8 +93,9 @@
 #  - Telecoms Cloud Networks Limited: Telecoms Cloud
 #  - Teleena UK Limited: Teleena
 #  - Telefonica UK Limited: O2
+#  - Telency Limited: Telency
 #  - Telesign Mobile Limited: Telesign
-#  - Telsis Systems Ltd: Telsis
+#  - Telet Research (N.I.) Limited: Telet Research
 #  - Test2date B.V: Test2date
 #  - Tismi BV: Tismi
 #  - Truphone Ltd: Truphone
@@ -111,19 +106,20 @@
 #  - Voicetec Systems Ltd: Voicetec
 #  - Voxbone SA: Voxbone
 #  - Wavecrest (UK) Ltd: Wavecrest
-#  - Yim Siam Telecom: Yim Siam
 #  - Ziron (UK) Ltd: Ziron
 #  - aql Wholesale Limited: aql
 
 447106|O2
 447107|O2
-447300|EE
-447301|EE
-447302|EE
-447303|EE
-447304|EE
+44730|EE
 447305|Virgin Mobile
 447306|Virgin Mobile
+447307|Three
+447308|Three
+447309|Three
+447310|Three
+447311|Three
+447312|Three
 447340|Vodafone
 447341|Vodafone
 447342|Vodafone
@@ -133,6 +129,11 @@
 4473680|Teleena
 4473682|Sky
 4473683|Sky
+4473684|Sky
+4473685|Sky
+4473686|Sky
+4473687|Vodafone
+4473690|Telet Research
 4473699|Anywhere Sim
 447375|EE
 447376|EE
@@ -140,8 +141,15 @@
 447378|Three
 4473780|Limitless
 447379|Vodafone
-447380|Three
-4473800|AMSUK
+4473801|Three
+4473802|Three
+4473803|Three
+4473804|Three
+4473805|Three
+4473806|Three
+4473807|Three
+4473808|Three
+4473809|Three
 447381|O2
 447382|O2
 447383|Three
@@ -152,10 +160,6 @@
 447388|Vodafone
 4473890|Three
 4473891|Three
-4473892|TalkTalk
-4473893|TalkTalk
-4473894|TalkTalk
-4473895|TalkTalk
 4473896|Hanhaa
 4473897|Vodafone
 4473898|Vodafone
@@ -222,16 +226,13 @@
 4474187|Teleena
 4474189|Teleena
 447419|Orange
+44742|Three
 447420|Orange
 447421|Orange
 447422|Orange
 447423|Vodafone
 447424|Lycamobile
 447425|Vodafone
-447426|Three
-447427|Three
-447428|Three
-447429|Three
 447430|O2
 447431|O2
 447432|EE
@@ -241,10 +242,6 @@
 447436|Vodafone
 447437|Vodafone
 447438|Lycamobile
-4474390|TalkTalk
-4474391|TalkTalk
-4474392|TalkTalk
-4474393|TalkTalk
 447440|Lycamobile
 4474408|Telecoms Cloud
 4474409|Cloud9
@@ -266,11 +263,15 @@
 447448|Lycamobile
 447449|Three
 447450|Three
-447451|Vectone Mobile
+4474510|Vectone Mobile
+4474511|Vectone Mobile
 4474512|Tismi
-4474515|Premium O
+4474513|Vectone Mobile
+4474514|Vectone Mobile
 4474516|UK Broadband
 4474517|UK Broadband
+4474518|Vectone Mobile
+4474519|Vectone Mobile
 447452|Manx Telecom
 4474527|Three
 4474528|Three
@@ -279,33 +280,26 @@
 447454|Three
 447455|Three
 447456|Three
-4474570|Vectone Mobile
-4474571|Vectone Mobile
+447457|Vectone Mobile
 4474572|Marathon Telecom
-4474573|Vectone Mobile
 4474574|Voicetec
-4474575|Vectone Mobile
 4474576|Sure
 4474577|Spacetel
 4474578|CardBoardFish
 4474579|CardBoardFish
-4474580|Gamma Telecom
-4474581|Gamma Telecom
+447458|Gamma Telecom
 4474582|Premium Routing
 4474583|Virgin Mobile
 4474584|Airwave
 4474585|Marathon Telecom
 4474586|Three
-4474587|Limitless
-4474588|Limitless
+4474587|Simetric Telecom
+4474588|Simetric Telecom
 4474589|Three
 447459|Lycamobile
-447460|Three
+44746|Three
 447461|O2
-447462|Three
-447463|Three
 447464|Vodafone
-447465|Three
 4474650|Vectone Mobile
 4474651|Vectone Mobile
 4474653|Compatel
@@ -317,34 +311,23 @@
 44747|Three
 447470|Vodafone
 447471|Vodafone
+44748|EE
 447480|Three
 447481|Three
 447482|Three
-447483|EE
-447484|EE
-447485|EE
-447486|EE
-447487|EE
+447488|Three
 4474880|Fogg
 4474881|CESG
 4474882|Sky
 4474883|Sky
-4474884|Three
-4474885|Three
 4474886|Lanonyx
-4474887|Three
 4474888|Ziron
-4474889|Three
 447489|O2
+44749|EE
 447490|Three
 447491|Three
 447492|Three
 447493|Vodafone
-447494|EE
-447495|EE
-447496|EE
-447497|EE
-447498|EE
 447499|O2
 447500|Vodafone
 447501|Vodafone
@@ -386,7 +369,6 @@
 4475322|Orange
 4475323|Orange
 4475324|Orange
-4475325|SMSRelay AG
 4475326|Three
 4475327|Three
 4475328|Three
@@ -417,7 +399,6 @@
 4475580|Mobile FX Services Ltd
 4475588|Cloud9
 4475590|Mars
-4475591|LegendTel
 4475592|IPV6
 4475593|Globecom
 4475594|Truphone
@@ -428,8 +409,6 @@
 4475599|Resilient
 44756|O2
 447570|Vodafone
-4475710|09 Mobile
-4475718|Alliance
 447572|EE
 447573|EE
 447574|EE
@@ -447,7 +426,6 @@
 447586|Vodafone
 447587|Vodafone
 447588|Three
-4475890|Yim Siam
 4475891|Oxygen8
 4475892|Oxygen8
 4475893|Oxygen8
@@ -464,8 +442,16 @@
 4476020|O2
 4476022|Relax
 447623|PageOne
-447624|Manx Telecom
+4476240|Manx Telecom
+4476241|Manx Telecom
 4476242|Sure
+4476243|Manx Telecom
+4476244|Manx Telecom
+44762450|Bluewave Communications
+44762456|Sure
+4476246|Manx Telecom
+4476248|Manx Telecom
+4476249|Manx Telecom
 447625|O2
 447626|O2
 4476400|Core Telecom
@@ -476,7 +462,6 @@
 4476406|PageOne
 4476407|PageOne
 4476411|Orange
-4476433|Yim Siam
 4476440|O2
 4476441|O2
 4476446|Media
@@ -499,11 +484,7 @@
 4476604|PageOne
 4476605|PageOne
 4476606|24 Seven
-4476607|Premium O
-4476608|Premium O
-4476609|Premium O
 447661|PageOne
-4476620|Premium O
 4476633|Syntec
 4476636|Relax
 4476637|Vodafone
@@ -519,31 +500,36 @@
 4476699|O2
 4476770|24 Seven
 4476772|Relax
-4476776|Telsis
+4476776|Telency
 4476778|Core Telecom
 4476810|PageOne
 4476814|PageOne
 4476818|PageOne
 447693|O2
 447699|Vodafone
-44770|O2
 4477000|Cloud9
 4477001|Nationwide Telephone
 4477003|Sure
 4477007|Sure
 4477008|Sure
+447701|O2
+447702|O2
+447703|O2
+447704|O2
+447705|O2
+447706|O2
+447707|O2
+447708|O2
+447709|O2
 44771|O2
 447717|Vodafone
-447720|O2
+44772|O2
 447721|Vodafone
 447722|EE
 447723|Three
-447724|O2
-447725|O2
 447726|EE
 447727|Three
 447728|Three
-447729|O2
 44773|O2
 447733|Vodafone
 447735|Three
@@ -601,19 +587,17 @@
 447794|Orange
 447795|Vodafone
 447796|Vodafone
-447797|JT
+4477977|JT
+4477978|JT
+4477979|JT
 447798|Vodafone
 447799|Vodafone
+44780|O2
 447800|Orange
-447801|O2
-447802|O2
-447803|O2
 447804|EE
 447805|Orange
 447806|EE
 447807|Orange
-447808|O2
-447809|O2
 44781|Orange
 447810|Vodafone
 447818|Vodafone
@@ -622,7 +606,6 @@
 447821|O2
 4478220|FleXtel
 4478221|Swiftnet
-4478222|TalkTalk
 4478224|aql
 4478225|Icron Network
 4478226|aql
@@ -655,15 +638,11 @@
 447846|Three
 447847|EE
 447848|Three
-447850|O2
-447851|O2
+44785|O2
 447852|EE
 447853|Three
 447854|Orange
 447855|Orange
-447856|O2
-447857|O2
-447858|O2
 447859|Three
 447860|O2
 447861|Three
@@ -704,14 +683,11 @@
 447877|Three
 447878|Three
 447879|Vodafone
-447880|Vodafone
-447881|Vodafone
+44788|Vodafone
 447882|Three
 447883|Three
-447884|Vodafone
 447885|O2
 447886|Three
-447887|Vodafone
 447888|Three
 447889|O2
 447890|Orange
@@ -728,7 +704,6 @@
 4478930|Magrathea
 4478931|24 Seven
 4478932|O2
-4478933|Yim Siam
 4478934|O2
 4478935|O2
 4478936|O2
@@ -741,15 +716,11 @@
 447897|Three
 447898|Three
 447899|Vodafone
+44790|EE
 447900|Vodafone
 447901|Vodafone
 447902|O2
-447903|EE
-447904|EE
-447905|EE
-447906|EE
 447907|O2
-447908|EE
 447909|Vodafone
 447910|EE
 4479110|Marathon Telecom
@@ -765,20 +736,29 @@
 447917|Vodafone
 447918|Vodafone
 447919|Vodafone
-44792|O2
 447920|Vodafone
-447924|Manx Telecom
-4479245|Cloud9
+447921|O2
+447922|O2
+447923|O2
+4479240|Manx Telecom
+4479241|Manx Telecom
+4479242|Manx Telecom
+4479243|Manx Telecom
+4479244|Manx Telecom
+4479246|Manx Telecom
+4479247|Manx Telecom
+4479248|Manx Telecom
+4479249|Manx Telecom
+447925|O2
+447926|O2
+447927|O2
+447928|O2
 447929|Orange
+44793|O2
 447930|EE
 447931|EE
 447932|EE
-447933|O2
-447934|O2
-447935|O2
-447936|O2
 447937|JT
-447938|O2
 447939|EE
 44794|EE
 44795|EE


### PR DESCRIPTION
The recent release (v8.9.10) updated the GB Carrier data, however, it was still out of date.

This merge updates to the latest data from Ofcom, generated on 2018-11-13 using https://github.com/giggsey/GBCarrierGenerator

Replaces #2006 