### PR TITLE
Defensive check added to FormatInOriginalFormat

### DIFF
--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -14,9 +14,9 @@
 
 #include "phonenumbers/phonenumberutil.h"
 
-#include <string.h>
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <iterator>
 #include <map>
 #include <utility>
@@ -1426,8 +1426,14 @@ void PhoneNumberUtil::FormatInOriginalFormat(const PhoneNumber& number,
       // We assume that the first-group symbol will never be _before_ the
       // national prefix.
       if (!candidate_national_prefix_rule.empty()) {
-        candidate_national_prefix_rule.erase(
-            candidate_national_prefix_rule.find("$1"));
+	size_t index_of_first_group = candidate_national_prefix_rule.find("$1");
+        if (index_of_first_group == string::npos) {
+          LOG(ERROR) << "First group missing in national prefix rule: "
+              << candidate_national_prefix_rule;
+          Format(number, NATIONAL, formatted_number);
+          break;
+        }
+        candidate_national_prefix_rule.erase(index_of_first_group);
         NormalizeDigitsOnly(&candidate_national_prefix_rule);
       }
       if (candidate_national_prefix_rule.empty()) {

--- a/cpp/src/phonenumbers/phonenumberutil.cc
+++ b/cpp/src/phonenumbers/phonenumberutil.cc
@@ -1426,7 +1426,7 @@ void PhoneNumberUtil::FormatInOriginalFormat(const PhoneNumber& number,
       // We assume that the first-group symbol will never be _before_ the
       // national prefix.
       if (!candidate_national_prefix_rule.empty()) {
-	size_t index_of_first_group = candidate_national_prefix_rule.find("$1");
+        size_t index_of_first_group = candidate_national_prefix_rule.find("$1");
         if (index_of_first_group == string::npos) {
           LOG(ERROR) << "First group missing in national prefix rule: "
               << candidate_national_prefix_rule;


### PR DESCRIPTION
Add a check that the FG is indeed in the national prefix before erasing it, in FormatInOriginalFormat. Matches java interpretation. It should always be there but if for some reason someone generates metadata with it not there we don't want to seg fault.