### PR TITLE
Wataniya changed to Ooredoo

### DIFF
--- a/resources/carrier/ar/965.txt
+++ b/resources/carrier/ar/965.txt
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 9655|فيفا
-9656|الوطنية
+9656|أوريدو
 9659|زين


### PR DESCRIPTION
updating the forgotten arabic rename of Wataniya to Ooredoo

more info at https://en.wikipedia.org/wiki/Ooredoo and http://news.kuwaittimes.net/wataniya-becomes-ooredoo-global-brand-telecom-player-now-operates-15-countries-serves-97000000-customers/