### PR TITLE
JS changes for PR #2295

### DIFF
--- a/javascript/i18n/phonenumbers/phonenumberutil_test.js
+++ b/javascript/i18n/phonenumbers/phonenumberutil_test.js
@@ -310,9 +310,9 @@ function testGetInstanceLoadARMetadata() {
   assertEquals('0(?:(11|343|3715)15)?', metadata.getNationalPrefixForParsing());
   assertEquals('9$1', metadata.getNationalPrefixTransformRule());
   assertEquals('$2 15 $3-$4', metadata.getNumberFormat(2).getFormat());
-  assertEquals('(9)(\\d{4})(\\d{2})(\\d{4})',
+  assertEquals('(\\d)(\\d{4})(\\d{2})(\\d{4})',
                metadata.getNumberFormat(3).getPattern());
-  assertEquals('(9)(\\d{4})(\\d{2})(\\d{4})',
+  assertEquals('(\\d)(\\d{4})(\\d{2})(\\d{4})',
                metadata.getIntlNumberFormat(3).getPattern());
   assertEquals('$1 $2 $3 $4', metadata.getIntlNumberFormat(3).getFormat());
 }


### PR DESCRIPTION
Removing the code to convert specific digits to \d.
More details in PR #2295 and CL/222974757
Note: We encountered this JS unit test failure during release as we maintain it externally first.