### PR TITLE
 Updating "commons-fileupload" version number from 1.3 to 1.3.2

### DIFF
--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.3</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>


### PR DESCRIPTION
Followup to PR #2298 as sub version number is not mentioned earlier. GitHub has suggested it to be >~1.3.2. So just making it to 1.3.2 and it will be in line with commons-io version.