### PR TITLE
21st century format for US phone numbers

### DIFF
--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -25714,7 +25714,7 @@
              longer optional and should not be in brackets. -->
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixOptionalWhenFormatting="true">
           <leadingDigits>[2-9]</leadingDigits>
-          <format>($1) $2-$3</format>
+          <format>$1-$2-$3</format>
           <intlFormat>$1-$2-$3</intlFormat>
         </numberFormat>
       </availableFormats>


### PR DESCRIPTION
At the end of the 20th century, 7-digit dialing was deprecated and finally disabled for phone systems across the United States. During a transition period in 1996, attempting to dial using 7 digits would result in a recorded message to inform you of the upcoming change. In 1998 most cities switched to 10-digit dialing. And in 1999 the transition was complete.

Previously, it was possible to call a local number by dialing 7-digits, which would connect based on the area you were dialing from, i.e. the calling subscriber's area code. At that time, the number format (212) 222-3456 was appropriate because the 212 was optional.

But in this millennium, everybody (nearly everybody?) MUST use 10 digit dialing to successfully connect a call. In other words, the area code is mandatory. This means that a more appropriate representation of phone numbers in the United States is the 212-222-3456 format.

Both formats are still used in the wild. And of course in many places you will still see signs on the street with a 7 digit number. One day [on the side of the road](https://www.google.com/maps/@40.12495,-75.0630202,3a,15y,175.05h,89.57t/data=!3m6!1e1!3m4!1sC_ssKzg5KZVLwXiliiyweg!2e0!7i16384!8i8192) I even saw a road sign using the early 20th century number format, which is WORD-#-#### where WORD is any word whose first two letters can be translated into the numbers. It is cute to see this nostalgia and ask my grandparents why a phone number is a word plus 5 digits.

Now that it is 20 years since USA switched to this new dialing process it is time for us to accept this reality and switch the default for libphonenumber.

---

# References 

The authoritative entity for managing phone number resources in the USA is the North American Numbering Plan Administration. Please note that [on their own contact page](https://www.nationalnanpa.com/contact_us/index.html) they do cite phone numbers in the XXX-XXX-XXXX format. 

## Authoritative references:

- https://www.nationalnanpa.com/enas/npasRequiring10DigitReport.do
- https://www.nationalnanpa.com/pdf/PL_381.pdf
- https://www.nationalnanpa.com/pdf/pl-nanp-136.pdf
- https://www.nationalnanpa.com/pdf/newsletters/NANPA_3Q09.pdf

## Anecdotal references (including outdated information):

- https://en.wikipedia.org/wiki/Seven-digit_dialing#1995_to_present
- https://boards.straightdope.com/sdmb/archive/index.php/t-150745.html
- https://en.wikipedia.org/wiki/Telephone_numbering_plan#Area_code