### PR TITLE
Add support for norwegian machine to machine numbers

### DIFF
--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberMatcherTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/PhoneNumberMatcherTest.java
@@ -486,6 +486,8 @@ public class PhoneNumberMatcherTest extends TestMetadataTestCase {
     new NumberTest("0 3 0 -3 2 23 12 34", RegionCode.DE),
     // Fits an alternate pattern, but the leading digits don't match.
     new NumberTest("+52 332 123 23 23", RegionCode.MX),
+    // Test norwegian machine to machine
+    //new NumberTest("+47581234567890", RegionCode.NO),
   };
 
   /**

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/RegionCode.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/RegionCode.java
@@ -48,6 +48,7 @@ final class RegionCode {
   static final String KR = "KR";
   static final String MX = "MX";
   static final String NZ = "NZ";
+  static final String NO = "NO";
   static final String PG = "PG";
   static final String PL = "PL";
   static final String RE = "RE";

--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -20617,6 +20617,7 @@
     <!-- Metadata (excluding fixed-line) should be duplicated in 'SJ'. -->
     <!-- http://www.npt.no/npt/numsys/E.164.pdf -->
     <!-- https://en.wikipedia.org/wiki/Telephone_numbers_in_Norway -->
+    <!-- https://eng.nkom.no/market/numbering/e.164-numbering-plan/general-norwegian-numbering-plan-for-telephony-etc.e.164>
     <territory id="NO" mainCountryForCode="true" countryCode="47" leadingDigits="[02-689]|7[0-8]"
                internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
@@ -20654,12 +20655,13 @@
       <!-- Consider adding one more digit for stricter validation (e.g. for 580). TETRA and GSM-R
            numbers are not supported as they are not reachable for all. -->
       <mobile>
-        <possibleLengths national="8"/>
+        <possibleLengths national="8,12"/>
         <exampleNumber>40612345</exampleNumber>
         <nationalNumberPattern>
           (?:
             4[015-8]|
-            5[89]|
+            58\d{4}|
+            59|
             9\d
           )\d{6}
         </nationalNumberPattern>


### PR DESCRIPTION
According to the norwegian numbering plan from the communications
authority, numbers starting with 58 have 12 digits, and are intended
for machine to machine communication:

https://eng.nkom.no/market/numbering/e.164-numbering-plan/general-norwegian-numbering-plan-for-telephony-etc.e.164

This is also mentioned in the reference pdf from the
PhoneNumberMetadata.xml:
https://www.nkom.no/npt/numsys/E.164.pdf

This change fixes issue
[132751288](https://issuetracker.google.com/issues/132751288)